### PR TITLE
fix(scanner): show all sessions on cold start instead of only last 2 days

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "gui")]
 
-use tauri::Manager;
+use tauri::{Listener, Manager};
 
 fn main() {
     tracing_subscriber::fmt::init();
@@ -76,6 +76,69 @@ fn main() {
                     }
                 });
             }
+
+            // Start periodic write buffer flush (buffers session writes to reduce DB I/O)
+            tauri::async_runtime::spawn(async move {
+                let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
+                loop {
+                    interval.tick().await;
+                    if let Some((sessions, details)) =
+                        pi_session_manager::write_buffer::check_and_take_flush_data()
+                    {
+                        let sessions_count = sessions.len();
+                        let details_count = details.len();
+                        if let Ok(conn) = pi_session_manager::sqlite_cache::init_db() {
+                            for entry in sessions {
+                                let _ = pi_session_manager::sqlite_cache::upsert_session(
+                                    &conn,
+                                    &entry.session,
+                                    entry.file_modified,
+                                    None,
+                                );
+                            }
+                            for entry in details {
+                                let _ =
+                                    pi_session_manager::sqlite_cache::upsert_session_details_cache(
+                                        &conn,
+                                        &entry.path,
+                                        entry.file_modified,
+                                        &entry.details,
+                                    );
+                            }
+                            log::trace!(
+                                "Flushed {sessions_count} sessions and {details_count} details to database"
+                            );
+                        }
+                    }
+                }
+            });
+
+            // Flush write buffer on app exit
+            app.handle().clone().listen("tauri://exit", |_| {
+                if let Some((sessions, details)) =
+                    pi_session_manager::write_buffer::force_flush_all()
+                {
+                    if let Ok(conn) = pi_session_manager::sqlite_cache::init_db() {
+                        for entry in sessions {
+                            let _ = pi_session_manager::sqlite_cache::upsert_session(
+                                &conn,
+                                &entry.session,
+                                entry.file_modified,
+                                None,
+                            );
+                        }
+                        for entry in details {
+                            let _ =
+                                pi_session_manager::sqlite_cache::upsert_session_details_cache(
+                                    &conn,
+                                    &entry.path,
+                                    entry.file_modified,
+                                    &entry.details,
+                                );
+                        }
+                    }
+                }
+            });
 
             if cli_mode {
                 let mut info = String::from("CLI mode:");

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -167,6 +167,7 @@ pub async fn scan_sessions_with_config(config: &Config) -> Result<Vec<SessionInf
                                     };
 
                                     if file_modified > realtime_cutoff {
+                                        // Recent file: parse from disk, add to results, buffer for DB
                                         if let Ok((info, _entries)) = parse_session_info(&file_path)
                                         {
                                             sessions.push(info);
@@ -178,20 +179,31 @@ pub async fn scan_sessions_with_config(config: &Config) -> Result<Vec<SessionInf
                                     } else if let Some(cached_mtime) =
                                         sqlite_cache::get_cached_file_modified(&conn, &path_str)?
                                     {
+                                        // In DB: re-parse only if file changed since last cache
                                         if file_modified > cached_mtime {
-                                            if let Ok((info, _entries)) =
+                                            if let Ok((info, entries)) =
                                                 parse_session_info(&file_path)
                                             {
-                                                write_buffer::buffer_session_write(
+                                                let _ = sqlite_cache::upsert_session(
+                                                    &conn,
                                                     &info,
                                                     file_modified,
+                                                    Some(&entries),
                                                 );
                                             }
                                         }
-                                    } else if let Ok((info, _entries)) =
-                                        parse_session_info(&file_path)
-                                    {
-                                        write_buffer::buffer_session_write(&info, file_modified);
+                                    } else {
+                                        // Not in DB (cold start): parse and write directly to DB
+                                        if let Ok((info, entries)) =
+                                            parse_session_info(&file_path)
+                                        {
+                                            let _ = sqlite_cache::upsert_session(
+                                                &conn,
+                                                &info,
+                                                file_modified,
+                                                Some(&entries),
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -200,6 +212,7 @@ pub async fn scan_sessions_with_config(config: &Config) -> Result<Vec<SessionInf
                 }
             }
 
+            // Load all historical sessions from DB (now populated for cold start too)
             let historical_sessions =
                 sqlite_cache::get_sessions_modified_before(&conn, realtime_cutoff)?;
 
@@ -217,8 +230,8 @@ pub async fn scan_sessions_with_config(config: &Config) -> Result<Vec<SessionInf
                 .count();
             let historical_count = sessions.len() - realtime_count;
 
-            trace!(
-                "Scan complete: {} realtime (≤{}d), {} historical (>{}d), total {}",
+            info!(
+                "Scan complete: {} realtime (≤{}d), {} historical (>{}d), {} total",
                 realtime_count,
                 config.realtime_cutoff_days,
                 historical_count,


### PR DESCRIPTION
## Problem

On a fresh install (or after a DB reset), the app only shows sessions from the last 2 days instead of all available sessions. Users with hundreds of sessions dating back weeks see only a handful.

## Root Cause

The session scanner uses a 2-layer architecture:
- **Recent sessions** (within `realtime_cutoff_days`, default 2) are parsed from disk on every scan
- **Older sessions** are loaded from the SQLite cache

This completely breaks on cold start due to two bugs:

### Bug 1: Scanner buffered old sessions instead of writing them to the DB

When a session file was older than the cutoff and not yet in the SQLite cache, the scanner parsed it and passed it to an in-memory write buffer — but never added it to the scan result. The idea was that the buffer would flush to the DB asynchronously, and a subsequent scan would pick them up. In practice, even if the buffer did flush, the in-memory scan cache (`SCAN_CACHE`) still held the incomplete first result and was never invalidated.

### Bug 2: Write buffer flush timer was dead code in the GUI binary

The periodic flush task (every 10s) and exit-time flush handler existed in `lib.rs::run()`, but `main.rs` defines its own `tauri::Builder` with its own `setup()` closure and **never calls `run()`**. The timer was effectively dead code — it never ran.

## Fix

1. **`scanner.rs`**: On cold start, write uncached old sessions directly to the DB via `upsert_session()` during the scan itself, so the historical query at the end of the same scan picks them up immediately.

2. **`main.rs`**: Add the write buffer flush timer (10s interval) and exit handler to the actual GUI app setup, where they were missing.

## Testing

On a machine with 310 session files dating back to Jan 28:
- **Before**: Only ~47 sessions visible (last 2 days)
- **After**: All 309 sessions visible immediately on first launch

All existing tests pass (`cargo test` — 12 passed).