### PR TITLE
Session tree "Labeled" filter fix on macOS

### DIFF
--- a/src/components/session-tree/SessionTree.tsx
+++ b/src/components/session-tree/SessionTree.tsx
@@ -116,6 +116,7 @@ interface SessionTreeProps {
   entries: SessionEntry[];
   activeLeafId?: string;
   onNodeClick?: (leafId: string, targetId: string) => void;
+  resolvedLabelsByTargetId?: Record<string, string>;
   filter?:
     | "default"
     | "no-tools"
@@ -149,6 +150,7 @@ const SessionTree = memo(
       entries,
       activeLeafId,
       onNodeClick,
+      resolvedLabelsByTargetId,
       filter = "no-tools",
     }: SessionTreeProps,
     ref,
@@ -245,6 +247,7 @@ const SessionTree = memo(
             parentNode.push({
               entry,
               children: childrenMap.get(entry.id) || [],
+              label: resolvedLabelsByTargetId?.[entry.id],
             });
           }
         }
@@ -256,6 +259,7 @@ const SessionTree = memo(
           const node: TreeNodeData = {
             entry,
             children: childrenMap.get(entry.id) || [],
+            label: resolvedLabelsByTargetId?.[entry.id],
           };
           roots.push(node);
         }
@@ -273,9 +277,9 @@ const SessionTree = memo(
       roots.forEach(sortChildren);
 
       return roots;
-    }, [entries]);
+   }, [entries, resolvedLabelsByTargetId]);
 
-    // Flatten tree with proper indentation and connectors
+     // Flatten tree with proper indentation and connectors
     const flatNodes = useMemo(() => {
       const result: FlatNode[] = [];
       const multipleRoots = treeData.length > 1;

--- a/src/components/session-viewer/SessionViewerSidebar.tsx
+++ b/src/components/session-viewer/SessionViewerSidebar.tsx
@@ -1,8 +1,25 @@
-import type { CSSProperties, MouseEventHandler, RefObject } from "react";
+import { useMemo, type CSSProperties, type MouseEventHandler, type RefObject } from "react";
 
 import SessionTree, { type SessionTreeRef } from "@/components/session-tree/SessionTree";
 
 import type { SessionEntry } from "@/types";
+
+/** Resolve label entries into a targetId → label text map (latest-wins by file order) */
+function resolveLabelsFromEntries(entries: SessionEntry[]): Record<string, string> {
+  const labels = new Map<string, string>();
+  for (const entry of entries) {
+    if (entry.type !== "label" || !entry.targetId?.trim()) {
+      continue;
+    }
+    const text = entry.label?.trim() ?? "";
+    if (text) {
+      labels.set(entry.targetId, text);
+    } else {
+      labels.delete(entry.targetId);
+    }
+  }
+  return Object.fromEntries(labels);
+}
 
 export interface SessionViewerSidebarProps {
   showSidebar: boolean;
@@ -37,6 +54,11 @@ export default function SessionViewerSidebar({
   outlineTitle,
   hideSidebarTitle,
 }: SessionViewerSidebarProps) {
+  const resolvedLabelsByTargetId = useMemo(
+    () => resolveLabelsFromEntries(entries),
+    [entries],
+  );
+
   if (!showSidebar) {
     return null;
   }
@@ -104,6 +126,7 @@ export default function SessionViewerSidebar({
             entries={entries}
             activeLeafId={activeEntryId ?? undefined}
             onNodeClick={onNodeClick}
+            resolvedLabelsByTargetId={resolvedLabelsByTargetId}
           />
         </div>
       </aside>

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -203,7 +203,8 @@ function normalizeSessionEntry(raw: any): SessionEntry | null {
     type === 'toolCall' ||
     type === 'custom_message' ||
     type === 'compaction' ||
-    type === 'branch_summary'
+    type === 'branch_summary' ||
+    type === 'label'
   ) {
     return raw as SessionEntry
   }


### PR DESCRIPTION
The session tree's "Labeled" filter wasn't working in the Tauri macOS app: clicking it would show an empty list for sessions with labeled nodes.  Two issues contributed:
1. `normalizeSessionEntry` in the client-side JSONL parser didn't include `type === 'label'` in its passthrough list, so label entries were silently dropped before they reached the component tree
2. `SessionViewerSidebar` never resolved label data from the entries it already holds, so `SessionTree` received no `resolvedLabelsByTargetId` and the filter had nothing to match against

In the web app (tested in Chrome and Brave), the filter has been working, however, and I believe that that app has been falling back to a browser-dataset provider that resolves labels through a separate path - whereas the Tauri app had been routing through a backend invoke that returned an empty map.

This PR fixes both issues: label entries now survive JSONL parsing, and the sidebar resolves them into a `targetId → label text` map using the same latest-wins-by-file-order semantics that Pi uses for label resolution.

Changes:
- **session parser**: add `'label'` to the `normalizeSessionEntry` passthrough so label entries are preserved during JSONL parsing
- **sidebar**: add `resolveLabelsFromEntries` helper that iterates label entries and builds a `targetId → label text` map; derive `resolvedLabelsByTargetId` via `useMemo` over `entries` and pass it to `SessionTree`
- **session tree**: accept `resolvedLabelsByTargetId` prop and wire it into tree node construction for both child and root nodes

Checks from README.md:
- All passing except `cargo test`, where all tests pass except `test_full_text_search_thinking_toggle` (which was already failing before these commits)