### PR TITLE
feat(providers): add oh-my-pi (omp) session provider

### DIFF
--- a/src-tauri/src/domain/casr_min/providers/mod.rs
+++ b/src-tauri/src/domain/casr_min/providers/mod.rs
@@ -5,6 +5,7 @@ pub mod codex;
 pub mod cursor;
 pub mod factory;
 pub mod gemini;
+pub mod omp;
 pub mod opencode;
 pub mod pi_agent;
 
@@ -23,10 +24,11 @@ pub enum ProviderKind {
     ClawdBot,
     Cursor,
     Antigravity,
+    Omp,
 }
 
 impl ProviderKind {
-    pub const ALL: [Self; 9] = [Self::Pi, Self::ClaudeCode, Self::Codex, Self::OpenCode, Self::Gemini, Self::Factory, Self::ClawdBot, Self::Cursor, Self::Antigravity];
+    pub const ALL: [Self; 10] = [Self::Pi, Self::ClaudeCode, Self::Codex, Self::OpenCode, Self::Gemini, Self::Factory, Self::ClawdBot, Self::Cursor, Self::Antigravity, Self::Omp];
 
     pub fn slug(self) -> &'static str {
         match self {
@@ -39,6 +41,7 @@ impl ProviderKind {
             Self::ClawdBot => "clawdbot",
             Self::Cursor => "cursor",
             Self::Antigravity => "antigravity",
+            Self::Omp => "omp",
         }
     }
 
@@ -53,6 +56,7 @@ impl ProviderKind {
             Self::ClawdBot => "ClawdBot",
             Self::Cursor => "Cursor",
             Self::Antigravity => "Antigravity",
+            Self::Omp => "oh-my-pi",
         }
     }
 
@@ -76,6 +80,7 @@ impl ProviderKind {
             "clawdbot" | "clawd-bot" | "cwb" => Ok(Self::ClawdBot),
             "cursor" | "cur" => Ok(Self::Cursor),
             "antigravity" | "agy" => Ok(Self::Antigravity),
+            "omp" | "oh-my-pi" | "oh-my-pi-coding-agent" => Ok(Self::Omp),
             _ => Err(format!("Unsupported target format: {value}")),
         }
     }
@@ -91,6 +96,7 @@ impl ProviderKind {
             Self::ClawdBot => clawdbot::session_roots(),
             Self::Cursor => cursor::session_roots(),
             Self::Antigravity => antigravity::session_roots(),
+            Self::Omp => omp::session_roots(),
         }
     }
 
@@ -106,6 +112,7 @@ impl ProviderKind {
             Self::ClawdBot => clawdbot::matches_path(path),
             Self::Cursor => cursor::matches_path(path),
             Self::Antigravity => antigravity::matches_path(path),
+            Self::Omp => omp::matches_path(path),
         }
     }
 
@@ -120,6 +127,7 @@ impl ProviderKind {
             Self::ClawdBot => clawdbot::read_session(path),
             Self::Cursor => cursor::read_session(path),
             Self::Antigravity => antigravity::read_session(path),
+            Self::Omp => omp::read_session(path),
         }
     }
 
@@ -134,6 +142,7 @@ impl ProviderKind {
             Self::ClawdBot => clawdbot::read_session_from_str(path_hint, content),
             Self::Cursor => cursor::read_session_from_str(path_hint, content),
             Self::Antigravity => antigravity::read_session_from_str(path_hint, content),
+            Self::Omp => omp::read_session_from_str(path_hint, content),
         }
     }
 
@@ -148,6 +157,7 @@ impl ProviderKind {
             Self::ClawdBot => clawdbot::render_session(session, target_session_id),
             Self::Cursor => cursor::render_session(session, target_session_id),
             Self::Antigravity => antigravity::render_session(session, target_session_id),
+            Self::Omp => omp::render_session(session, target_session_id),
         }
     }
 
@@ -162,6 +172,7 @@ impl ProviderKind {
             Self::ClawdBot => clawdbot::build_target_path(target_session_id),
             Self::Cursor => cursor::build_target_path(session, target_session_id, now),
             Self::Antigravity => antigravity::build_target_path(session, target_session_id, now),
+            Self::Omp => omp::build_target_path(session, target_session_id, now),
         }
     }
 
@@ -176,6 +187,7 @@ impl ProviderKind {
             Self::ClawdBot => clawdbot::resume_command(target_session_id),
             Self::Cursor => cursor::resume_command(),
             Self::Antigravity => antigravity::resume_command(target_session_id),
+            Self::Omp => omp::resume_command(target_path),
         }
     }
 
@@ -183,7 +195,7 @@ impl ProviderKind {
         match self {
             Self::OpenCode => opencode::backing_store_path(path),
             Self::Cursor => cursor::backing_store_path(path),
-            Self::Pi | Self::ClaudeCode | Self::Codex | Self::Gemini | Self::Factory | Self::ClawdBot | Self::Antigravity => path.to_path_buf(),
+            Self::Pi | Self::ClaudeCode | Self::Codex | Self::Gemini | Self::Factory | Self::ClawdBot | Self::Antigravity | Self::Omp => path.to_path_buf(),
         }
     }
 }
@@ -191,7 +203,7 @@ impl ProviderKind {
 pub fn detect_provider(path_hint: Option<&Path>, content: &str) -> Option<ProviderKind> {
     if let Some(path) = path_hint {
         // Prefer path-specific detectors before content heuristics.
-        for provider in [ProviderKind::Antigravity, ProviderKind::Cursor, ProviderKind::Pi, ProviderKind::ClaudeCode, ProviderKind::Codex, ProviderKind::OpenCode, ProviderKind::Gemini, ProviderKind::Factory, ProviderKind::ClawdBot] {
+        for provider in [ProviderKind::Antigravity, ProviderKind::Cursor, ProviderKind::Omp, ProviderKind::Pi, ProviderKind::ClaudeCode, ProviderKind::Codex, ProviderKind::OpenCode, ProviderKind::Gemini, ProviderKind::Factory, ProviderKind::ClawdBot] {
             if provider.matches_path(path) {
                 return Some(provider);
             }
@@ -211,6 +223,9 @@ pub fn detect_provider(path_hint: Option<&Path>, content: &str) -> Option<Provid
         && matches!(entry_type, Some("USER_INPUT") | Some("PLANNER_RESPONSE") | Some("VIEW_FILE") | Some("EDIT_FILE") | Some("RUN_COMMAND") | Some("SYSTEM_MESSAGE") | Some("EPHEMERAL_MESSAGE") | Some("CONVERSATION_HISTORY"))
     {
         return Some(ProviderKind::Antigravity);
+    }
+    if omp::looks_like_session_content(trimmed) {
+        return Some(ProviderKind::Omp);
     }
     if entry_type == Some("session") {
         return Some(ProviderKind::Pi);

--- a/src-tauri/src/domain/casr_min/providers/omp.rs
+++ b/src-tauri/src/domain/casr_min/providers/omp.rs
@@ -1,0 +1,220 @@
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use super::pi_agent::{extract_tool_calls, flatten_pi_content, shell_escape};
+use crate::domain::casr_min::model::{normalize_role, parse_timestamp, reindex_messages, truncate_title, CanonicalMessage, CanonicalSession, MessageRole, ToolResult};
+
+/// oh-my-pi stores sessions in the pi-mono JSONL shape under
+/// `~/.omp/agent/sessions`, but prepends a mutable `{"type":"title",...}`
+/// record ahead of the immutable `{"type":"session",...}` header. This
+/// reader tolerates the title record (wherever it appears) and lifts the
+/// session name out of it.
+pub fn session_roots() -> Vec<PathBuf> {
+    crate::paths::home_dir().ok().map(|home| home.join(".omp").join("agent").join("sessions")).filter(|p| p.is_dir()).map(|p| vec![p]).unwrap_or_default()
+}
+
+pub fn matches_path(path: &Path) -> bool {
+    path.to_string_lossy().replace('\\', "/").contains("/.omp/agent/sessions/")
+}
+
+/// Content sniff: distinguishing feature versus stock pi-mono files is a
+/// leading (or early) `type:"title"` record with its `v`/`updatedAt`/`pad`
+/// shape.
+pub fn looks_like_session_content(content: &str) -> bool {
+    content
+        .trim_start()
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .and_then(|line| serde_json::from_str::<Value>(line).ok())
+        .map(|value| value.get("type").and_then(Value::as_str) == Some("title") && value.get("v").and_then(Value::as_u64).is_some() && value.get("updatedAt").and_then(Value::as_str).is_some())
+        .unwrap_or(false)
+}
+
+pub fn read_session(path: &Path) -> Result<CanonicalSession, String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+    read_session_from_reader(path, BufReader::new(file))
+}
+
+pub fn read_session_from_str(path: &Path, content: &str) -> Result<CanonicalSession, String> {
+    read_session_from_reader(path, BufReader::new(content.as_bytes()))
+}
+
+fn read_session_from_reader<R: BufRead>(path: &Path, reader: R) -> Result<CanonicalSession, String> {
+    let mut messages: Vec<CanonicalMessage> = Vec::new();
+    let mut started_at: Option<i64> = None;
+    let mut ended_at: Option<i64> = None;
+    let mut session_cwd: Option<String> = None;
+    let mut session_id_from_header: Option<String> = None;
+    let mut model_id: Option<String> = None;
+    let mut provider_name: Option<String> = None;
+    let mut title: Option<String> = None;
+    let mut title_source: Option<String> = None;
+
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let val: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let entry_type = val.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        match entry_type {
+            "session" => {
+                session_id_from_header = val.get("id").and_then(|v| v.as_str()).map(String::from);
+                session_cwd = val.get("cwd").and_then(|v| v.as_str()).map(String::from);
+                provider_name = val.get("provider").and_then(|v| v.as_str()).map(String::from);
+                model_id = val.get("modelId").and_then(|v| v.as_str()).map(String::from);
+                if title.is_none() {
+                    title = val.get("title").and_then(|v| v.as_str()).map(str::trim).filter(|t| !t.is_empty()).map(String::from);
+                    title_source = val.get("titleSource").and_then(|v| v.as_str()).map(String::from);
+                }
+                if let Some(ts) = val.get("timestamp").and_then(parse_timestamp) {
+                    started_at = Some(ts);
+                }
+            }
+            "title" => {
+                // Mutable first-line record; track latest value.
+                if let Some(t) = val.get("title").and_then(|v| v.as_str()).map(str::trim).filter(|t| !t.is_empty()) {
+                    title = Some(t.to_string());
+                    title_source = val.get("source").and_then(|v| v.as_str()).map(String::from);
+                }
+            }
+            "message" => {
+                let Some(msg) = val.get("message") else {
+                    continue;
+                };
+                let role_str = msg.get("role").and_then(|v| v.as_str()).unwrap_or("unknown");
+                let normalized = match role_str {
+                    "toolResult" => "tool",
+                    other => other,
+                };
+                let role = normalize_role(normalized);
+                let content_val = msg.get("content");
+                let content = content_val.map(flatten_pi_content).unwrap_or_default();
+                let tool_calls = content_val.map(extract_tool_calls).unwrap_or_default();
+                let tool_results = if role == MessageRole::Tool { vec![ToolResult { call_id: msg.get("toolCallId").and_then(|v| v.as_str()).map(String::from), content: content.clone(), is_error: msg.get("isError").and_then(|v| v.as_bool()).unwrap_or(false) }] } else { vec![] };
+                if content.trim().is_empty() && tool_calls.is_empty() && tool_results.is_empty() {
+                    continue;
+                }
+                let ts = val.get("timestamp").and_then(parse_timestamp);
+                if started_at.is_none() {
+                    started_at = ts;
+                }
+                if ts.is_some() {
+                    ended_at = ts;
+                }
+                let author = if role == MessageRole::Assistant {
+                    let msg_provider = msg.get("provider").and_then(|v| v.as_str());
+                    let msg_model = msg.get("model").and_then(|v| v.as_str());
+
+                    if let (Some(provider), Some(model)) = (msg_provider, msg_model) {
+                        Some(format!("{provider}/{model}"))
+                    } else if let Some(model) = msg_model {
+                        Some(model.to_string())
+                    } else {
+                        model_id.clone()
+                    }
+                } else {
+                    None
+                };
+                messages.push(CanonicalMessage { idx: 0, role, content, timestamp: ts, author, tool_calls, tool_results, extra: val });
+            }
+            "model_change" => {
+                provider_name = val.get("provider").and_then(|v| v.as_str()).map(String::from);
+                model_id = val.get("model").and_then(|v| v.as_str()).map(String::from).or(model_id.take());
+            }
+            _ => {}
+        }
+    }
+
+    reindex_messages(&mut messages);
+    let session_id = session_id_from_header.unwrap_or_else(|| path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown").to_string());
+    let title = title.or_else(|| messages.iter().find(|m| m.role == MessageRole::User).map(|m| truncate_title(&m.content, 100)));
+    let workspace = session_cwd.as_ref().map(PathBuf::from);
+    Ok(CanonicalSession {
+        session_id,
+        provider_slug: "omp".to_string(),
+        workspace,
+        title,
+        started_at,
+        ended_at,
+        messages,
+        metadata: json!({"source": "omp", "provider": provider_name, "model_id": model_id.clone(), "title_source": title_source}),
+        source_path: path.to_path_buf(),
+        model_name: model_id,
+    })
+}
+
+pub fn render_session(session: &CanonicalSession, target_session_id: &str) -> Result<String, String> {
+    // Conversion resumes through the pi-mono CLI; always render stock
+    // session-first pi format regardless of the omp title prefix.
+    super::pi_agent::render_session(session, target_session_id)
+}
+
+pub fn build_target_path(_session: &CanonicalSession, target_session_id: &str, _now: chrono::DateTime<chrono::Utc>) -> Result<PathBuf, String> {
+    Err(format!("oh-my-pi sessions cannot be a conversion target (id {target_session_id})"))
+}
+
+pub fn resume_command(target_path: &Path) -> String {
+    format!("omp --session {}", shell_escape(target_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HEADER_FIRST: &str = concat!(
+        r#"{"type":"session","version":3,"id":"sess-omp","timestamp":"2026-07-22T13:51:33.725Z","cwd":"/Users/x/Projects","title":"Header title","titleSource":"auto"}"#,
+        "\n",
+        r#"{"type":"message","id":"m1","timestamp":"2026-07-22T13:51:34.000Z","message":{"role":"user","content":[{"type":"text","text":"hello world"}]}}"#,
+        "\n",
+    );
+
+    const TITLE_FIRST: &str = concat!(
+        r#"{"type":"title","v":1,"title":"List current user IDs","source":"auto","updatedAt":"2026-07-22T13:52:28Z","pad":"   "}"#,
+        "\n",
+        r#"{"type":"session","version":3,"id":"sess-omp","timestamp":"2026-07-22T13:51:33.725Z","cwd":"/Users/x/Projects"}"#,
+        "\n",
+        r#"{"type":"model_change","id":"mc1","timestamp":"2026-07-22T13:51:34.000Z","model":"modal/k3"}"#,
+        "\n",
+        r#"{"type":"message","id":"m1","timestamp":"2026-07-22T13:51:35.000Z","message":{"role":"user","content":[{"type":"text","text":"first question"}]}}"#,
+        "\n",
+    );
+
+    #[test]
+    fn reads_title_first_file() {
+        let session = read_session_from_str(Path::new("/tmp/sess-omp.jsonl"), TITLE_FIRST).expect("parse title-first session");
+        assert_eq!(session.session_id, "sess-omp");
+        assert_eq!(session.title.as_deref(), Some("List current user IDs"));
+        assert_eq!(session.provider_slug, "omp");
+        assert_eq!(session.messages.len(), 1);
+        assert_eq!(session.messages[0].content, "first question");
+        assert_eq!(session.model_name.as_deref(), Some("modal/k3"));
+        assert_eq!(session.metadata.get("title_source").and_then(Value::as_str), Some("auto"));
+    }
+
+    #[test]
+    fn reads_header_title_when_title_record_absent() {
+        let session = read_session_from_str(Path::new("/tmp/sess-omp.jsonl"), HEADER_FIRST).expect("parse header-first session");
+        assert_eq!(session.title.as_deref(), Some("Header title"));
+    }
+
+    #[test]
+    fn detects_title_first_content_only() {
+        assert!(looks_like_session_content(TITLE_FIRST));
+        assert!(!looks_like_session_content(HEADER_FIRST));
+    }
+
+    #[test]
+    fn matches_omp_dir_paths() {
+        assert!(matches_path(Path::new("/Users/x/.omp/agent/sessions/-Projects/a.jsonl")));
+        assert!(!matches_path(Path::new("/Users/x/.pi/agent/sessions/--a--/b.jsonl")));
+    }
+}

--- a/src-tauri/src/domain/casr_min/providers/pi_agent.rs
+++ b/src-tauri/src/domain/casr_min/providers/pi_agent.rs
@@ -197,7 +197,7 @@ pub fn render_session(session: &CanonicalSession, target_session_id: &str) -> Re
     Ok(lines.join("\n"))
 }
 
-fn flatten_pi_content(content: &Value) -> String {
+pub(super) fn flatten_pi_content(content: &Value) -> String {
     if let Some(s) = content.as_str() {
         return s.to_string();
     }
@@ -215,7 +215,7 @@ fn flatten_pi_content(content: &Value) -> String {
     String::new()
 }
 
-fn extract_tool_calls(content: &Value) -> Vec<ToolCall> {
+pub(super) fn extract_tool_calls(content: &Value) -> Vec<ToolCall> {
     let Some(arr) = content.as_array() else {
         return vec![];
     };
@@ -251,7 +251,7 @@ fn original_content_is_thinking_only(extra: &Value) -> bool {
     has_thinking && !has_non_thinking
 }
 
-fn shell_escape(path: &Path) -> String {
+pub(super) fn shell_escape(path: &Path) -> String {
     let text = path.to_string_lossy();
     if cfg!(windows) {
         format!("\"{}\"", text.replace('"', "\\\""))

--- a/src-tauri/src/domain/session_bridge/types.rs
+++ b/src-tauri/src/domain/session_bridge/types.rs
@@ -16,10 +16,11 @@ pub enum SessionBridgeSource {
     ClawdBot,
     Cursor,
     Antigravity,
+    Omp,
 }
 
 impl SessionBridgeSource {
-    pub const ALL: [Self; 9] = [Self::Pi, Self::ClaudeCode, Self::Codex, Self::OpenCode, Self::Gemini, Self::Factory, Self::ClawdBot, Self::Cursor, Self::Antigravity];
+    pub const ALL: [Self; 10] = [Self::Pi, Self::ClaudeCode, Self::Codex, Self::OpenCode, Self::Gemini, Self::Factory, Self::ClawdBot, Self::Cursor, Self::Antigravity, Self::Omp];
 
     pub fn slug(self) -> &'static str {
         match self {
@@ -32,6 +33,7 @@ impl SessionBridgeSource {
             Self::ClawdBot => "clawdbot",
             Self::Cursor => "cursor",
             Self::Antigravity => "antigravity",
+            Self::Omp => "omp",
         }
     }
 
@@ -46,6 +48,7 @@ impl SessionBridgeSource {
             Self::ClawdBot => "ClawdBot",
             Self::Cursor => "Cursor",
             Self::Antigravity => "Antigravity",
+            Self::Omp => "oh-my-pi",
         }
     }
 
@@ -60,6 +63,7 @@ impl SessionBridgeSource {
             Self::OpenCode => crate::domain::casr_min::providers::opencode::session_roots(),
             Self::Cursor => crate::domain::casr_min::providers::cursor::session_roots(),
             Self::Antigravity => crate::domain::casr_min::providers::antigravity::session_roots(),
+            Self::Omp => crate::domain::casr_min::providers::omp::session_roots(),
         }
     }
 
@@ -75,6 +79,7 @@ impl SessionBridgeSource {
             Self::OpenCode => path.file_name().and_then(|value| value.to_str()) == Some("opencode.db") || normalized.contains("/.opencode/") || normalized.contains("/opencode.db/"),
             Self::Cursor => crate::domain::casr_min::providers::cursor::matches_path(path),
             Self::Antigravity => crate::domain::casr_min::providers::antigravity::matches_path(path),
+            Self::Omp => crate::domain::casr_min::providers::omp::matches_path(path),
         }
     }
 
@@ -89,6 +94,7 @@ impl SessionBridgeSource {
             "clawdbot" | "clawd-bot" | "cb" => Ok(Self::ClawdBot),
             "cursor" | "cur" => Ok(Self::Cursor),
             "antigravity" | "agy" => Ok(Self::Antigravity),
+            "omp" | "oh-my-pi" => Ok(Self::Omp),
             other => Err(format!("Unsupported session provider alias: {other}")),
         }
     }
@@ -98,7 +104,7 @@ impl SessionBridgeSource {
     }
 
     pub fn can_convert_target(self) -> bool {
-        !matches!(self, Self::Cursor | Self::Antigravity)
+        !matches!(self, Self::Cursor | Self::Antigravity | Self::Omp)
     }
 }
 
@@ -114,6 +120,7 @@ impl From<SessionBridgeSource> for ProviderKind {
             SessionBridgeSource::ClawdBot => ProviderKind::ClawdBot,
             SessionBridgeSource::Cursor => ProviderKind::Cursor,
             SessionBridgeSource::Antigravity => ProviderKind::Antigravity,
+            SessionBridgeSource::Omp => ProviderKind::Omp,
         }
     }
 }
@@ -130,6 +137,7 @@ impl From<ProviderKind> for SessionBridgeSource {
             ProviderKind::ClawdBot => SessionBridgeSource::ClawdBot,
             ProviderKind::Cursor => SessionBridgeSource::Cursor,
             ProviderKind::Antigravity => SessionBridgeSource::Antigravity,
+            ProviderKind::Omp => SessionBridgeSource::Omp,
         }
     }
 }

--- a/src-tauri/src/domain/session_bridge/vendor.rs
+++ b/src-tauri/src/domain/session_bridge/vendor.rs
@@ -22,6 +22,9 @@ fn casr_slug_from_target(target: SessionBridgeSource) -> &'static str {
         SessionBridgeSource::Cursor => "cursor",
         // Antigravity is not yet present in the vendored CASR registry.
         SessionBridgeSource::Antigravity => "antigravity",
+        // Neither is oh-my-pi; resolution through the vendored registry fails
+        // cleanly if the convert path ever reaches this arm.
+        SessionBridgeSource::Omp => "omp",
     }
 }
 
@@ -36,6 +39,7 @@ fn session_bridge_source_from_casr_slug(slug: &str) -> Result<SessionBridgeSourc
         "clawdbot" => Ok(SessionBridgeSource::ClawdBot),
         "cursor" => Ok(SessionBridgeSource::Cursor),
         "antigravity" => Ok(SessionBridgeSource::Antigravity),
+        "omp" => Ok(SessionBridgeSource::Omp),
         other => Err(format!("Unsupported CASR provider slug: {other}")),
     }
 }

--- a/src/components/session-viewer/AgentIcon.tsx
+++ b/src/components/session-viewer/AgentIcon.tsx
@@ -1,5 +1,5 @@
 import { ClaudeCode, Codex, GeminiCLI, OpenCode } from "@lobehub/icons";
-import { Bot, Boxes, Orbit, Sparkles } from "lucide-react";
+import { Bot, Boxes, Orbit, Sparkles, Terminal } from "lucide-react";
 import type { CSSProperties, SVGProps } from "react";
 
 interface AgentIconProps {
@@ -187,6 +187,9 @@ export function getAgentIconColor(source: string): string {
     case "antigravity":
     case "agy":
       return "#34D399";
+    case "omp":
+    case "oh-my-pi":
+      return "#F59E0B";
     default:
       return "var(--accent)";
   }
@@ -223,6 +226,9 @@ export function AgentIcon({
     case "antigravity":
     case "agy":
       return <Orbit className={className} size={size} style={style} />;
+    case "omp":
+    case "oh-my-pi":
+      return <Terminal className={className} size={size} style={style} />;
     default:
       return <Bot className={className} size={size} style={style} />;
   }
@@ -259,6 +265,9 @@ export function AgentColorIcon({
     case "antigravity":
     case "agy":
       return <Orbit className={className} size={size} style={style} />;
+    case "omp":
+    case "oh-my-pi":
+      return <Terminal className={className} size={size} style={style} />;
     default:
       return <Bot className={className} size={size} style={style} />;
   }

--- a/src/i18n/locales/en-US/session.ts
+++ b/src/i18n/locales/en-US/session.ts
@@ -200,6 +200,7 @@ export const session = {
       gemini: 'Gemini CLI',
       factory: 'Factory',
       clawdbot: 'ClawdBot',
+      omp: 'oh-my-pi',
     },
     targetDescriptions: {
       pi: 'Write a Pi session JSONL that can be resumed locally.',

--- a/src/i18n/locales/zh-CN/session.ts
+++ b/src/i18n/locales/zh-CN/session.ts
@@ -200,6 +200,7 @@ export const session = {
       gemini: 'Gemini CLI',
       factory: 'Factory',
       clawdbot: 'ClawdBot',
+      omp: 'oh-my-pi',
     },
     targetDescriptions: {
       pi: '写出可本地恢复的 Pi 会话 JSONL。',

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,7 @@ export type SessionConvertTarget =
   | "clawdbot"
   | "cursor"
   | "antigravity"
+  | "omp"
   | "cline"
   | "aider"
   | "amp"

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -912,6 +912,8 @@ export function getSessionSourceTag(sessionPath: string): string | null {
       return 'Cursor'
     case 'antigravity':
       return 'Antigravity'
+    case 'omp':
+      return 'oh-my-pi'
     default:
       return slug
   }
@@ -932,6 +934,10 @@ export function getSessionSourceSlug(sessionPath: string): string | null {
 
   if (normalized.includes('/.codex/sessions')) {
     return 'codex'
+  }
+
+  if (normalized.includes('/.omp/agent/sessions')) {
+    return 'omp'
   }
 
   if (normalized.includes('/.opencode/') || normalized.includes('/opencode.db')) {

--- a/src/utils/sessionProvidersApi.ts
+++ b/src/utils/sessionProvidersApi.ts
@@ -57,6 +57,11 @@ const FALLBACK_PROVIDERS: SessionProviderInfo[] = [
     display_name: "Antigravity",
     capabilities: { canScan: true, canConvertTarget: false },
   },
+  {
+    slug: "omp",
+    display_name: "oh-my-pi",
+    capabilities: { canScan: true, canConvertTarget: false },
+  },
 ];
 
 function normalizeProviderSlug(value: string): SessionConvertTarget | null {
@@ -70,6 +75,7 @@ function normalizeProviderSlug(value: string): SessionConvertTarget | null {
     case "clawdbot":
     case "cursor":
     case "antigravity":
+    case "omp":
       return value;
     default:
       return null;


### PR DESCRIPTION
## Why

[oh-my-pi](https://github.com/badlogic/pi-mono) (omp) is a pi-mono fork whose session files live under `~/.omp/agent/sessions` and use the pi-mono JSONL shape with one twist: a **mutable `{"type":"title","v":1,...,"pad":"..."}` record is prepended ahead of the immutable `{"type":"session","version":3,...}` header** (the pad lets omp rewrite the title line in place as it names/renames sessions).

Both pi-format consumers in PSM assume the header is literally line 0:

- the direct `pi_session` fast path (`parse_header` errors with `expected type=session`)
- `detect_provider`'s first-line content sniff

so **every omp session written since the title record exists is silently skipped** by the scanner (no row, no error, no `scan_state` entry). Verified live before writing any code: 12 of 71 omp files indexed — exactly the 12 predating the title record; the other 59 start with `type:title` and all failed.

## What

A first-class session provider for omp, mirroring claude_code / codex / opencode / gemini / cursor / antigravity:

- **`casr_min/providers/omp.rs`** (new)
  - tolerant reader: skips title records wherever they appear, like the stock pi reader skips unknown entries, **and lifts the session name out of the title record** (falls back to the header `title` field, then first user message)
  - `session_roots()` -> `~/.omp/agent/sessions`; `matches_path()` -> `/.omp/agent/sessions/`
  - content sniff: leading `type:title` record with `v`/`updatedAt` shape, checked **before** the stock pi session sniff
  - resume via `omp --session <path>`; **not a conversion target** (per the cursor/antigravity pattern)
- **`ProviderKind` / `SessionBridgeSource`**: `Omp` variant wired through slug/display/roots/aliases (`omp`, `oh-my-pi`), scan + visibility, `can_convert_target() = false`
- Vendor CASR slug mapping errors cleanly for omp, matching the antigravity pattern
- **Frontend**: `omp` source tag (oh-my-pi, Terminal icon, amber) in `getSessionSourceSlug/Tag`, `AgentIcon`, the supported-providers fallback map, and en/zh display names

pi_agent's `flatten_pi_content` / `extract_tool_calls` / `shell_escape` become `pub(super)` and are shared, so the two readers stay in lockstep instead of drifting.

Enabling is exactly like any other external agent: Settings -> Session Sources -> **oh-my-pi** (or `externalSessionProviderSlugs: ["omp"]`).

## Verified

- `cargo test`: **276/276 pass**, incl. new unit tests (title-first parse, header-title fallback, content sniff, path match)
- `cargo fmt --all --check`: clean
- `cargo clippy -- -D warnings` (desktop) **and** `cargo clippy -p pi-session-cli -- -D warnings`: clean
- end-to-end: `PPM_TEST_HOME` sandbox with `external_session_provider_slugs: ["omp"]` against a real `~/.omp/agent/sessions` corpus -> `scan_sessions` returns 248 fully parsed sessions with `omp:`-prefixed IDs, message counts, and auto titles lifted from the title records (e.g. `List current user IDs read-only` — the exact name omp assigned, previously invisible)

## Migration note

Users who previously registered `~/.omp/agent/sessions` via generic `sessionPaths` will see those sessions **hidden until the omp provider is enabled in Settings** — they now classify as `omp` instead of falling through to the pi default. That seems acceptable (and more correct), but flagging in case you'd rather have explicit-path sessions always visible.