### PR TITLE
feat(omp): adapt OMP session messages and tool rendering

### DIFF
--- a/extensions/psm-cross-agent-tool-renderer/index.test.tsx
+++ b/extensions/psm-cross-agent-tool-renderer/index.test.tsx
@@ -21,6 +21,55 @@ describe('crossAgentToolRenderer', () => {
     expect(crossAgentToolRenderer.getPreview!(toolCall, data)).toBe('Shell: cargo test')
   })
 
+  it('recognizes OMP grep and todo tools', () => {
+    const grepCall = {
+      type: 'toolCall' as const,
+      id: 'call-grep',
+      name: 'grep',
+      arguments: { pattern: 'upload', i: 'find upload references' },
+    }
+    const todoCall = {
+      type: 'toolCall' as const,
+      id: 'call-todo',
+      name: 'todo',
+      arguments: { op: 'init', i: 'init deploy tasks', items: ['build', 'deploy'] },
+    }
+
+    expect(crossAgentToolRenderer.match(grepCall)).toBe(true)
+    expect(crossAgentToolRenderer.match(todoCall)).toBe(true)
+    expect(crossAgentToolRenderer.getPreview!(grepCall, crossAgentToolRenderer.resolveData!(grepCall, 0, new Map()))).toBe('Grep: find upload references')
+    expect(crossAgentToolRenderer.getPreview!(todoCall, crossAgentToolRenderer.resolveData!(todoCall, 0, new Map()))).toBe('Tasks: init deploy tasks')
+  })
+
+  it('links OMP message-level tool results into renderer output', () => {
+    const toolCall = {
+      type: 'toolCall' as const,
+      id: 'call-grep',
+      name: 'grep',
+      arguments: { pattern: 'upload' },
+    }
+    const result = {
+      type: 'message',
+      id: 'omp-result',
+      message: {
+        role: 'toolResult',
+        toolCallId: 'call-grep',
+        toolName: 'grep',
+        content: [{ type: 'text', text: 'src/upload.ts:42' }],
+        isError: false,
+      },
+    } as any
+    const data = crossAgentToolRenderer.resolveData!(
+      toolCall,
+      0,
+      new Map([['call-grep', result]]),
+    )
+
+    expect(data.result).toBe(result)
+    expect(data.output).toBe('src/upload.ts:42')
+    expect(data.isError).toBe(false)
+  })
+
   it('recognizes Codex collaboration and wait tools', () => {
     for (const name of ['spawn_agent', 'list_agents', 'wait', 'wait_agent']) {
       expect(crossAgentToolRenderer.match({ type: 'toolCall', name })).toBe(true)

--- a/extensions/psm-cross-agent-tool-renderer/index.tsx
+++ b/extensions/psm-cross-agent-tool-renderer/index.tsx
@@ -1,7 +1,9 @@
 import {
   FilePenLine,
   FileText,
+  ListTodo,
   PlusSquare,
+  Search,
   Terminal,
   Wrench,
 } from "lucide-react";
@@ -25,6 +27,8 @@ type CrossAgentKind =
   | "read"
   | "write"
   | "edit"
+  | "search"
+  | "todo"
   | "agent"
   | "wait"
   | "generic";
@@ -33,6 +37,8 @@ const SHELL_TOOLS = new Set(["Bash", "bash", "shell", "exec"]);
 const READ_TOOLS = new Set(["Read", "read_file"]);
 const WRITE_TOOLS = new Set(["Write", "write_file"]);
 const EDIT_TOOLS = new Set(["Edit", "MultiEdit", "edit_file", "apply_patch"]);
+const SEARCH_TOOLS = new Set(["grep"]);
+const TODO_TOOLS = new Set(["todo"]);
 const AGENT_TOOLS = new Set([
   "spawn_agent",
   "send_message",
@@ -46,6 +52,8 @@ const CROSS_AGENT_TOOLS = new Set([
   ...READ_TOOLS,
   ...WRITE_TOOLS,
   ...EDIT_TOOLS,
+  ...SEARCH_TOOLS,
+  ...TODO_TOOLS,
   ...AGENT_TOOLS,
   ...WAIT_TOOLS,
 ]);
@@ -87,6 +95,8 @@ function getKind(name: string): CrossAgentKind {
   if (READ_TOOLS.has(name)) return "read";
   if (WRITE_TOOLS.has(name)) return "write";
   if (EDIT_TOOLS.has(name)) return "edit";
+  if (SEARCH_TOOLS.has(name)) return "search";
+  if (TODO_TOOLS.has(name)) return "todo";
   if (AGENT_TOOLS.has(name)) return "agent";
   if (WAIT_TOOLS.has(name)) return "wait";
   return "generic";
@@ -97,6 +107,8 @@ function getTitle(kind: CrossAgentKind, name: string): string {
   if (kind === "read") return "Read";
   if (kind === "write") return "Write";
   if (kind === "edit") return name === "apply_patch" ? "Patch" : "Edit";
+  if (kind === "search") return "Grep";
+  if (kind === "todo") return "Tasks";
   if (kind === "agent") return name === "list_agents" ? "Agents" : "Agent";
   if (kind === "wait") return "Wait";
   return name || "Tool";
@@ -115,6 +127,10 @@ function getPrimaryText(
     return getStringArg(args, "file_path", "path", "absolute_path") || name;
   if (kind === "edit")
     return getStringArg(args, "file_path", "path", "absolute_path") || name;
+  if (kind === "search")
+    return getStringArg(args, "i", "pattern", "query", "path") || name;
+  if (kind === "todo")
+    return getStringArg(args, "i", "op") || name;
   if (kind === "agent")
     return getStringArg(args, "task_name", "target", "message") || name;
   if (kind === "wait") {
@@ -160,7 +176,11 @@ function CrossAgentToolRenderer({
           ? PlusSquare
           : kind === "edit"
             ? FilePenLine
-            : Wrench;
+            : kind === "search"
+              ? Search
+              : kind === "todo"
+                ? ListTodo
+                : Wrench;
 
   return (
     <div

--- a/src/utils/session.test.ts
+++ b/src/utils/session.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { getSessionSourceSlug, getSessionSourceTag, parseSessionEntriesWithLineCount } from './session';
+import { findToolResult, getSessionSourceSlug, getSessionSourceTag, parseSessionEntriesWithLineCount } from './session';
 
 describe('parseSessionEntriesWithLineCount', () => {
   it('preserves raw Pi tree-advancing entries and their parent chain', () => {
@@ -131,6 +131,75 @@ describe('parseSessionEntriesWithLineCount', () => {
     expect(entries.find((entry) => entry.id === 'answer')?.parentId).toBe(
       'tool-call',
     )
+  })
+
+  it('preserves OMP v3 message blocks and links message-level tool results', () => {
+    const content = [
+      JSON.stringify({
+        type: 'message',
+        id: 'omp-user',
+        parentId: null,
+        timestamp: '2026-08-10T10:07:48.731Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Use direct upload' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: 'omp-assistant',
+        parentId: 'omp-user',
+        timestamp: '2026-08-10T10:07:51.444Z',
+        message: {
+          role: 'assistant',
+          content: [{
+            type: 'toolCall',
+            id: 'call-grep',
+            name: 'grep',
+            arguments: { pattern: 'upload', i: 'find upload references' },
+            intent: 'find upload references',
+          }],
+        },
+      }),
+      JSON.stringify({
+        type: 'custom',
+        customType: 'tool_execution_start',
+        data: { toolCallId: 'call-grep', toolName: 'grep' },
+        id: 'omp-tool-start',
+        parentId: 'omp-assistant',
+        timestamp: '2026-08-10T10:07:51.452Z',
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: 'omp-result',
+        parentId: 'omp-tool-start',
+        timestamp: '2026-08-10T10:07:51.903Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'call-grep',
+          toolName: 'grep',
+          content: [{ type: 'text', text: 'src/upload.ts:42' }],
+          isError: false,
+        },
+      }),
+    ].join('\n')
+
+    const { entries } = parseSessionEntriesWithLineCount(content)
+
+    expect(entries[0].message?.content).toEqual([
+      { type: 'text', text: 'Use direct upload' },
+    ])
+    expect(entries.find((entry) => entry.id === 'omp-tool-start')).toMatchObject({
+      type: 'custom',
+      customType: 'tool_execution_start',
+    })
+    expect(findToolResult(entries, 'call-grep')).toMatchObject({
+      id: 'omp-result',
+      message: {
+        role: 'toolResult',
+        toolCallId: 'call-grep',
+      },
+    })
   })
 
   it('links raw Codex function call output to its tool call id', () => {

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -185,7 +185,10 @@ export function findToolResult(
   return entries.find(
     e => e.type === 'message' &&
     e.message?.role === 'toolResult' &&
-    e.message?.content.some((c: any) => c.id === toolCallId)
+    (
+      e.message.toolCallId === toolCallId ||
+      e.message.content.some((c: any) => c.id === toolCallId || c.toolCallId === toolCallId)
+    )
   ) || null
 }
 


### PR DESCRIPTION
## Summary
- support OMP message-level `toolCallId` when resolving tool results
- extend the PSM cross-agent tool renderer for OMP `grep` and `todo`
- add a sanitized OMP v3 regression fixture covering text-block user messages, lifecycle entries, and tool-result pairing

## Validation
- `pnpm vitest run src/utils/session.test.ts extensions/psm-cross-agent-tool-renderer/index.test.tsx` — 21/21 passed
- `pnpm typecheck:extensions` — passed
- `pnpm build` — passed
- `git diff --check` — passed

Closes #50
