### PR TITLE
feat: add independent WSL session runtime

### DIFF
--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -104,6 +104,8 @@ pub fn run() {
             start_dataset_import,
             get_dataset_import_status,
             save_session_source,
+            list_wsl_distributions,
+            save_session_runtime_environment,
             save_session_scan_other_agents,
             save_external_session_providers,
             load_server_settings,
@@ -255,7 +257,7 @@ mod tests {
         let handler_set = handlers.iter().copied().collect::<BTreeSet<_>>();
         let dispatch_set = crate::dispatch::capability_command_catalog().collect::<BTreeSet<_>>();
 
-        assert_eq!(handlers.len(), 174);
+        assert_eq!(handlers.len(), 176);
         assert_eq!(handler_set.len(), handlers.len());
 
         let dispatch_only = dispatch_set.difference(&handler_set).copied().collect::<Vec<_>>();

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -195,12 +195,13 @@ pub async fn detect_session_format(path: String) -> Result<String, String> {
 
 #[cfg_attr(feature = "gui", tauri::command)]
 pub async fn list_supported_session_providers() -> Result<Vec<SessionProviderInfo>, String> {
+    let runtime_home = crate::paths::current_session_home_dir()?;
     Ok(crate::domain::session_bridge::SessionBridgeSource::ALL
         .into_iter()
         .map(|source| {
-            // session_roots() only yields directories that actually exist, so a
-            // non-empty result means the agent has sessions on this machine.
-            let roots: Vec<String> = source.session_roots().into_iter().map(|root| root.to_string_lossy().to_string()).collect();
+            // session_roots_for_home() only yields directories that actually exist,
+            // so a non-empty result means the agent has sessions in this runtime.
+            let roots: Vec<String> = source.session_roots_for_home(&runtime_home).into_iter().map(|root| root.to_string_lossy().to_string()).collect();
             SessionProviderInfo { slug: source.slug().replace('_', "-"), display_name: source.display_name().to_string(), capabilities: SessionProviderCapabilities { can_scan: source.can_scan(), can_convert_target: source.can_convert_target() }, detected: !roots.is_empty(), roots }
         })
         .collect())

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -129,11 +129,18 @@ fn inject_session_source_settings(settings: &mut Value) {
         crate::config::SessionSourceMode::Dataset => "dataset",
         crate::config::SessionSourceMode::Local => "local",
     };
+    let runtime_environment = match config.session_runtime_environment {
+        crate::config::SessionRuntimeEnvironment::Local => "local",
+        crate::config::SessionRuntimeEnvironment::Wsl => "wsl",
+    };
+    let wsl_distribution = config.wsl_distribution.clone().unwrap_or_default();
 
     let Some(root) = settings.as_object_mut() else {
         *settings = serde_json::json!({
             "session": {
                 "sourceMode": mode,
+                "runtimeEnvironment": runtime_environment,
+                "wslDistro": wsl_distribution,
                 "activeDatasetId": config.active_dataset_id,
             }
         });
@@ -146,6 +153,8 @@ fn inject_session_source_settings(settings: &mut Value) {
     }
     if let Some(session) = session_value.as_object_mut() {
         session.insert("sourceMode".to_string(), Value::String(mode.to_string()));
+        session.insert("runtimeEnvironment".to_string(), Value::String(runtime_environment.to_string()));
+        session.insert("wslDistro".to_string(), Value::String(wsl_distribution));
         session.insert("activeDatasetId".to_string(), config.active_dataset_id.clone().map(Value::String).unwrap_or(Value::Null));
         session.insert("activeDatasetIds".to_string(), Value::Array(config.effective_active_dataset_ids().into_iter().map(Value::String).collect()));
         session.insert("scanOtherAgentJsonl".to_string(), Value::Bool(config.scan_other_agent_jsonl));
@@ -161,6 +170,69 @@ fn inject_session_source_settings(settings: &mut Value) {
     if let Some(advanced) = advanced_value.as_object_mut() {
         advanced.insert("includeDefaultPiSessionDir".to_string(), Value::Bool(config.include_default_pi_session_dir));
     }
+}
+
+#[cfg_attr(feature = "gui", tauri::command)]
+pub async fn list_wsl_distributions() -> Result<Vec<String>, String> {
+    Ok(crate::paths::wsl_distribution_names())
+}
+
+pub async fn save_session_runtime_environment_core(environment: String, wsl_distribution: Option<String>) -> Result<bool, String> {
+    let normalized_environment = environment.trim().to_ascii_lowercase();
+    let runtime_environment = match normalized_environment.as_str() {
+        "local" => crate::config::SessionRuntimeEnvironment::Local,
+        "wsl" => crate::config::SessionRuntimeEnvironment::Wsl,
+        other => return Err(format!("Unsupported session runtime environment: {other}")),
+    };
+
+    let normalized_distribution = wsl_distribution.map(|value| value.trim().to_string()).filter(|value| !value.is_empty());
+    if runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl {
+        #[cfg(not(target_os = "windows"))]
+        return Err("WSL runtime is only available on Windows".to_string());
+
+        #[cfg(target_os = "windows")]
+        {
+            let distro = normalized_distribution.as_deref().ok_or_else(|| "WSL runtime requires a selected distribution".to_string())?;
+            if !crate::paths::wsl_distribution_names().iter().any(|candidate| candidate == distro) {
+                return Err(format!("WSL distribution is not available: {distro}"));
+            }
+            crate::paths::wsl_home_dir(distro)?;
+        }
+    }
+
+    let mut config = crate::config::Config::load().unwrap_or_default();
+    let next_distribution = if runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl { normalized_distribution } else { None };
+    if config.session_runtime_environment == runtime_environment && config.wsl_distribution == next_distribution {
+        return Ok(false);
+    }
+
+    config.session_runtime_environment = runtime_environment;
+    config.wsl_distribution = next_distribution;
+    crate::config::save_config(&config)?;
+
+    let conn = crate::data::sqlite::init_db_with_config(&config)?;
+    let _ = crate::data::sqlite::clear_all_cache(&conn)?;
+    crate::core::scanner::invalidate_cache();
+    Ok(true)
+}
+
+#[cfg(feature = "gui")]
+#[tauri::command]
+pub async fn save_session_runtime_environment(environment: String, wsl_distribution: Option<String>, app_handle: tauri::AppHandle) -> Result<(), String> {
+    if !save_session_runtime_environment_core(environment, wsl_distribution).await? {
+        return Ok(());
+    }
+
+    let watcher_state: tauri::State<'_, crate::file_watcher::FileWatcherState> = app_handle.state();
+    if let Err(error) = crate::file_watcher::restart_watcher_with_config(&watcher_state, app_handle.clone()) {
+        warn!("Failed to restart file watcher after session runtime change: {}", error);
+    }
+
+    if let Err(error) = refresh_sessions_after_settings_change(app_handle.clone()).await {
+        warn!("Failed to refresh sessions after session runtime change: {}", error);
+    }
+
+    Ok(())
 }
 
 /// Get configured session paths (extra paths beyond the default)

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -20,6 +20,14 @@ pub enum SessionSourceMode {
     Dataset,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum SessionRuntimeEnvironment {
+    #[default]
+    Local,
+    Wsl,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DatasetRegistryEntry {
@@ -75,6 +83,12 @@ pub struct Config {
 
     #[serde(default)]
     pub session_source_mode: SessionSourceMode,
+
+    #[serde(default)]
+    pub session_runtime_environment: SessionRuntimeEnvironment,
+
+    #[serde(default)]
+    pub wsl_distribution: Option<String>,
 
     #[serde(default)]
     pub active_dataset_id: Option<String>,
@@ -155,6 +169,8 @@ impl Default for Config {
             external_sessions_include_in_stats: false,
             external_sessions_include_in_search: false,
             session_source_mode: SessionSourceMode::Local,
+            session_runtime_environment: SessionRuntimeEnvironment::Local,
+            wsl_distribution: None,
             active_dataset_id: None,
             active_dataset_ids: vec![],
             datasets: vec![],

--- a/src-tauri/src/core/scanner.rs
+++ b/src-tauri/src/core/scanner.rs
@@ -237,7 +237,7 @@ pub fn get_cached_sessions_for_list() -> Option<Vec<SessionInfo>> {
 }
 
 pub fn get_sessions_dir() -> Result<PathBuf, String> {
-    crate::paths::pi_agent_sessions_dir()
+    Ok(crate::paths::current_session_home_dir()?.join(".pi").join("agent").join("sessions"))
 }
 
 /// Returns all session directories: the default one plus any user-configured paths.
@@ -257,11 +257,18 @@ pub fn get_all_session_dirs(config: &Config) -> Vec<PathBuf> {
     }
 
     let mut dirs = vec![];
+    let runtime_home = match crate::paths::session_runtime_home_dir(config) {
+        Ok(home) => home,
+        Err(error) => {
+            tracing::warn!("Unable to resolve session runtime home: {error}");
+            return dirs;
+        }
+    };
 
     for source in crate::domain::session_bridge::SessionBridgeSource::ALL {
         if source == crate::domain::session_bridge::SessionBridgeSource::Pi {
             if config.include_default_pi_session_dir {
-                for root in source.session_roots() {
+                for root in source.session_roots_for_home(&runtime_home) {
                     if root.exists() && !dirs.iter().any(|existing| existing == &root) {
                         dirs.push(root);
                     }
@@ -275,7 +282,7 @@ pub fn get_all_session_dirs(config: &Config) -> Vec<PathBuf> {
             continue;
         }
 
-        for root in source.session_roots() {
+        for root in source.session_roots_for_home(&runtime_home) {
             if root.exists() && !dirs.iter().any(|existing| existing == &root) {
                 dirs.push(root);
             }
@@ -284,7 +291,7 @@ pub fn get_all_session_dirs(config: &Config) -> Vec<PathBuf> {
 
     // User-configured extra paths
     for p in &config.session_paths {
-        let expanded = expand_tilde(p);
+        let expanded = expand_tilde(p, config, &runtime_home);
         let path = PathBuf::from(&expanded);
         if path.is_absolute() && !dirs.iter().any(|d| d == &path) {
             dirs.push(path);
@@ -294,25 +301,28 @@ pub fn get_all_session_dirs(config: &Config) -> Vec<PathBuf> {
     dirs
 }
 
-/// Expand ~ to home directory
-fn expand_tilde(path: &str) -> String {
-    let Ok(home) = crate::paths::home_dir() else {
-        return path.to_string();
-    };
-
-    if path == "~" {
-        return home.to_string_lossy().to_string();
-    }
-
-    if let Some(rest) = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\")) {
-        let mut expanded = home;
+/// Expand ~ to the active runtime home directory.
+fn expand_tilde(path: &str, config: &Config, home: &Path) -> String {
+    let expanded = if path == "~" {
+        home.to_string_lossy().to_string()
+    } else if let Some(rest) = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\")) {
+        let mut expanded = home.to_path_buf();
         for part in rest.split(['/', '\\']).filter(|segment| !segment.is_empty()) {
             expanded = expanded.join(part);
         }
-        return expanded.to_string_lossy().to_string();
+        expanded.to_string_lossy().to_string()
+    } else {
+        path.to_string()
+    };
+
+    #[cfg(target_os = "windows")]
+    if config.session_runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl && expanded.starts_with('/') {
+        if let Some(distro) = config.wsl_distribution.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+            return crate::paths::wsl_linux_path_to_unc(distro, &expanded).to_string_lossy().to_string();
+        }
     }
 
-    path.to_string()
+    expanded
 }
 
 pub async fn scan_sessions() -> Result<Vec<SessionInfo>, String> {

--- a/src-tauri/src/dispatch/mod.rs
+++ b/src-tauri/src/dispatch/mod.rs
@@ -100,7 +100,7 @@ mod tests {
     fn capability_command_catalog_is_unique_and_complete() {
         let commands = capability_command_catalog().collect::<Vec<_>>();
         let unique = commands.iter().copied().collect::<std::collections::HashSet<_>>();
-        assert_eq!(commands.len(), 160);
+        assert_eq!(commands.len(), 162);
         assert_eq!(unique.len(), commands.len());
     }
 

--- a/src-tauri/src/dispatch/settings.rs
+++ b/src-tauri/src/dispatch/settings.rs
@@ -12,6 +12,8 @@ pub(super) const COMMANDS: &[&str] = &[
     "start_dataset_import",
     "get_dataset_import_status",
     "save_session_source",
+    "list_wsl_distributions",
+    "save_session_runtime_environment",
     "save_session_scan_other_agents",
     "save_external_session_providers",
     "load_server_settings",
@@ -82,6 +84,16 @@ pub(super) async fn dispatch(app_state: &Option<DispatchAppState>, command: &str
                     let active_dataset_id = payload.get("active_dataset_id").or_else(|| payload.get("activeDatasetId")).and_then(|value| value.as_str()).map(ToString::to_string);
                     let active_dataset_ids = payload.get("active_dataset_ids").or_else(|| payload.get("activeDatasetIds")).and_then(|value| value.as_array()).map(|values| values.iter().filter_map(|value| value.as_str().map(ToString::to_string)).collect::<Vec<_>>());
                     crate::save_session_source_core(mode, active_dataset_id, active_dataset_ids).await?;
+                    Ok(Value::Null)
+                }
+                "list_wsl_distributions" => {
+                    let result = crate::list_wsl_distributions().await?;
+                    Ok(to_val(result, "serialize result")?)
+                }
+                "save_session_runtime_environment" => {
+                    let environment = payload.get("environment").and_then(|value| value.as_str()).unwrap_or("local").to_string();
+                    let wsl_distribution = payload.get("wslDistribution").or_else(|| payload.get("wsl_distribution")).and_then(|value| value.as_str()).map(ToString::to_string);
+                    crate::save_session_runtime_environment_core(environment, wsl_distribution).await?;
                     Ok(Value::Null)
                 }
                 "save_session_scan_other_agents" => {

--- a/src-tauri/src/domain/casr_min/bridge_ops.rs
+++ b/src-tauri/src/domain/casr_min/bridge_ops.rs
@@ -21,12 +21,15 @@ pub struct ConversionOutcome {
 }
 
 pub fn default_session_dirs(include_other_agents: bool) -> Vec<PathBuf> {
+    let Ok(runtime_home) = crate::paths::current_session_home_dir() else {
+        return Vec::new();
+    };
     let mut dirs = Vec::new();
     for provider in ProviderKind::ALL {
         if !include_other_agents && provider != ProviderKind::Pi {
             continue;
         }
-        for root in provider.session_roots() {
+        for root in provider.session_roots_for_home(&runtime_home) {
             if root.exists() && !dirs.iter().any(|existing| existing == &root) {
                 dirs.push(root);
             }

--- a/src-tauri/src/domain/casr_min/providers/antigravity.rs
+++ b/src-tauri/src/domain/casr_min/providers/antigravity.rs
@@ -9,7 +9,14 @@ use serde_json::{json, Map, Value};
 use crate::domain::casr_min::model::{parse_timestamp, reindex_messages, truncate_title, CanonicalMessage, CanonicalSession, MessageRole, ToolCall};
 
 pub fn session_roots() -> Vec<PathBuf> {
-    let base = base_root();
+    session_roots_from_base(base_root())
+}
+
+pub fn session_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    session_roots_from_base(home.join(".gemini").join("antigravity-cli"))
+}
+
+fn session_roots_from_base(base: PathBuf) -> Vec<PathBuf> {
     if !base.is_dir() {
         return Vec::new();
     }

--- a/src-tauri/src/domain/casr_min/providers/claude_code.rs
+++ b/src-tauri/src/domain/casr_min/providers/claude_code.rs
@@ -160,7 +160,7 @@ pub fn read_session_from_str(path: &Path, content: &str) -> Result<CanonicalSess
 }
 
 pub fn build_target_path(session: &CanonicalSession, target_session_id: &str) -> Result<PathBuf, String> {
-    let projects_dir = dirs::home_dir().map(|h| h.join(".claude").join("projects")).ok_or_else(|| "cannot determine Claude Code projects directory".to_string())?;
+    let projects_dir = crate::paths::current_session_home_dir()?.join(".claude").join("projects");
     let workspace_str = session.workspace.as_deref().unwrap_or(Path::new("/tmp"));
     let dir_key = project_dir_key(workspace_str);
     Ok(projects_dir.join(&dir_key).join(format!("{target_session_id}.jsonl")))

--- a/src-tauri/src/domain/casr_min/providers/clawdbot.rs
+++ b/src-tauri/src/domain/casr_min/providers/clawdbot.rs
@@ -19,7 +19,9 @@ pub fn matches_path(path: &Path) -> bool {
 }
 
 pub fn build_target_path(target_session_id: &str) -> Result<PathBuf, String> {
-    Ok(home_dir().join(format!("{target_session_id}.jsonl")))
+    let config = crate::config::Config::load().unwrap_or_default();
+    let root = if config.session_runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl { crate::paths::session_runtime_home_dir(&config)?.join(".clawdbot").join("sessions") } else { home_dir() };
+    Ok(root.join(format!("{target_session_id}.jsonl")))
 }
 
 pub fn resume_command(session_id: &str) -> String {

--- a/src-tauri/src/domain/casr_min/providers/codex.rs
+++ b/src-tauri/src/domain/casr_min/providers/codex.rs
@@ -10,7 +10,7 @@ pub fn session_roots() -> Vec<PathBuf> {
 }
 
 pub fn build_target_path(target_session_id: &str, now: DateTime<Utc>) -> Result<PathBuf, String> {
-    let sessions_dir = crate::paths::home_dir()?.join(".codex").join("sessions");
+    let sessions_dir = crate::paths::current_session_home_dir()?.join(".codex").join("sessions");
     let date_dir = now.format("%Y/%m/%d").to_string();
     let stamp = now.format("%Y-%m-%dT%H-%M-%S").to_string();
     Ok(sessions_dir.join(date_dir).join(format!("rollout-{stamp}-{target_session_id}.jsonl")))

--- a/src-tauri/src/domain/casr_min/providers/cursor.rs
+++ b/src-tauri/src/domain/casr_min/providers/cursor.rs
@@ -34,6 +34,10 @@ pub fn session_roots() -> Vec<PathBuf> {
     find_db_files()
 }
 
+pub fn session_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    find_db_files_in_config_dir(&home.join(".config").join("Cursor"))
+}
+
 pub fn matches_path(path: &Path) -> bool {
     is_db_path(path) || path.parent().is_some_and(|parent| parent.is_file() && parent.extension().and_then(|ext| ext.to_str()) == Some("vscdb"))
 }
@@ -120,6 +124,10 @@ fn find_db_files() -> Vec<PathBuf> {
     let Some(config_dir) = config_dir() else {
         return vec![];
     };
+    find_db_files_in_config_dir(&config_dir)
+}
+
+fn find_db_files_in_config_dir(config_dir: &Path) -> Vec<PathBuf> {
     let mut dbs = Vec::new();
     let global_db = config_dir.join("User/globalStorage/state.vscdb");
     if global_db.is_file() {

--- a/src-tauri/src/domain/casr_min/providers/factory.rs
+++ b/src-tauri/src/domain/casr_min/providers/factory.rs
@@ -20,7 +20,9 @@ pub fn matches_path(path: &Path) -> bool {
 
 pub fn build_target_path(session: &CanonicalSession, target_session_id: &str) -> Result<PathBuf, String> {
     let workspace_slug = session.workspace.as_ref().map(|path| encode_workspace_slug(path)).unwrap_or_else(|| "-tmp".to_string());
-    Ok(home_dir().join(workspace_slug).join(format!("{target_session_id}.jsonl")))
+    let config = crate::config::Config::load().unwrap_or_default();
+    let root = if config.session_runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl { crate::paths::session_runtime_home_dir(&config)?.join(".factory").join("sessions") } else { home_dir() };
+    Ok(root.join(workspace_slug).join(format!("{target_session_id}.jsonl")))
 }
 
 pub fn resume_command(session_id: &str) -> String {

--- a/src-tauri/src/domain/casr_min/providers/gemini.rs
+++ b/src-tauri/src/domain/casr_min/providers/gemini.rs
@@ -7,8 +7,17 @@ use sha2::{Digest, Sha256};
 use crate::domain::casr_min::model::{flatten_content, normalize_role, parse_timestamp, reindex_messages, truncate_title, CanonicalMessage, CanonicalSession, MessageRole, ToolCall, ToolResult};
 
 pub fn session_roots() -> Vec<PathBuf> {
-    gemini_tmp_dirs()
+    session_roots_from_tmp_dirs(gemini_tmp_dirs())
+}
+
+pub fn session_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    session_roots_from_tmp_dirs(vec![home.join(".gemini").join("tmp")])
+}
+
+fn session_roots_from_tmp_dirs(tmp_dirs: Vec<PathBuf>) -> Vec<PathBuf> {
+    tmp_dirs
         .into_iter()
+        .filter(|tmp| tmp.is_dir())
         .flat_map(|tmp| {
             std::fs::read_dir(&tmp)
                 .into_iter()
@@ -49,7 +58,8 @@ pub fn session_filename(session_id: &str, now: &chrono::DateTime<chrono::Utc>) -
 }
 
 pub fn build_target_path(session: &CanonicalSession, target_session_id: &str, now: chrono::DateTime<chrono::Utc>) -> Result<PathBuf, String> {
-    let tmp_dir = tmp_dir().ok_or_else(|| "cannot determine Gemini tmp directory".to_string())?;
+    let config = crate::config::Config::load().unwrap_or_default();
+    let tmp_dir = if config.session_runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl { crate::paths::session_runtime_home_dir(&config)?.join(".gemini").join("tmp") } else { tmp_dir().ok_or_else(|| "cannot determine Gemini tmp directory".to_string())? };
     let workspace_path = session.workspace.as_deref().unwrap_or(Path::new("/tmp"));
     let hash = session.metadata.get("project_hash").or_else(|| session.metadata.get("projectHash")).and_then(Value::as_str).map(ToString::to_string).unwrap_or_else(|| project_hash(workspace_path));
     let chats_dir = tmp_dir.join(hash).join("chats");
@@ -120,12 +130,7 @@ fn gemini_tmp_dirs() -> Vec<PathBuf> {
         return vec![tmp];
     }
 
-    crate::paths::local_and_wsl_home_dirs().into_iter().map(|home| home.join(".gemini").join("tmp")).filter(|path| path.is_dir()).fold(Vec::new(), |mut dirs, path| {
-        if !dirs.iter().any(|existing| existing == &path) {
-            dirs.push(path);
-        }
-        dirs
-    })
+    crate::paths::home_dir().ok().map(|home| home.join(".gemini").join("tmp")).filter(|path| path.is_dir()).map(|path| vec![path]).unwrap_or_default()
 }
 
 fn parse_root(path: &Path, root: &Value) -> Result<CanonicalSession, String> {

--- a/src-tauri/src/domain/casr_min/providers/mod.rs
+++ b/src-tauri/src/domain/casr_min/providers/mod.rs
@@ -86,25 +86,33 @@ impl ProviderKind {
     }
 
     pub fn session_roots(self) -> Vec<PathBuf> {
+        let config = crate::config::Config::load().unwrap_or_default();
+        let Ok(home) = crate::paths::session_runtime_home_dir(&config) else {
+            return Vec::new();
+        };
+        self.session_roots_for_home(&home)
+    }
+
+    pub fn session_roots_for_home(self, home: &Path) -> Vec<PathBuf> {
         match self {
-            Self::Pi => pi_agent::session_roots(),
-            Self::Omp => omp_agent::session_roots(),
-            Self::ClaudeCode => claude_code::session_roots(),
-            Self::Codex => codex::session_roots(),
-            Self::OpenCode => opencode::session_roots(),
-            Self::Gemini => gemini::session_roots(),
-            Self::Factory => factory::session_roots(),
-            Self::ClawdBot => clawdbot::session_roots(),
-            Self::Cursor => cursor::session_roots(),
-            Self::Antigravity => antigravity::session_roots(),
+            Self::Pi => crate::paths::existing_relative_dir(home, &[".pi", "agent", "sessions"]),
+            Self::Omp => crate::paths::existing_relative_dir(home, &[".omp", "agent", "sessions"]),
+            Self::ClaudeCode => crate::paths::existing_relative_dir(home, &[".claude", "projects"]),
+            Self::Codex => crate::paths::existing_relative_dir(home, &[".codex", "sessions"]),
+            Self::OpenCode => opencode::session_roots_for_home(home),
+            Self::Gemini => gemini::session_roots_for_home(home),
+            Self::Factory => crate::paths::existing_relative_dir(home, &[".factory", "sessions"]),
+            Self::ClawdBot => crate::paths::existing_relative_dir(home, &[".clawdbot", "sessions"]),
+            Self::Cursor => cursor::session_roots_for_home(home),
+            Self::Antigravity => antigravity::session_roots_for_home(home),
         }
     }
 
     pub fn matches_path(self, path: &Path) -> bool {
         let normalized = path.to_string_lossy().replace('\\', "/");
         match self {
-            Self::Pi => crate::paths::pi_agent_sessions_dir().ok().map(|path| path.to_string_lossy().replace('\\', "/")).is_some_and(|root| normalized.contains(&root)),
-            Self::Omp => crate::paths::omp_agent_sessions_dir().ok().map(|path| path.to_string_lossy().replace('\\', "/")).is_some_and(|root| normalized.contains(&root)),
+            Self::Pi => normalized.contains("/.pi/agent/sessions/"),
+            Self::Omp => normalized.contains("/.omp/agent/sessions/"),
             Self::ClaudeCode => normalized.contains("/.claude/projects/"),
             Self::Codex => normalized.contains("/.codex/sessions/"),
             Self::OpenCode => opencode::matches_path(path),
@@ -177,9 +185,16 @@ impl ProviderKind {
     }
 
     pub fn resume_command(self, target_session_id: &str, target_path: &Path) -> String {
+        let runtime_target_path = crate::config::Config::load()
+            .ok()
+            .filter(|config| config.session_runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl)
+            .and_then(|config| config.wsl_distribution)
+            .and_then(|distro| crate::paths::wsl_unc_path_to_linux(&distro, target_path))
+            .map(PathBuf::from)
+            .unwrap_or_else(|| target_path.to_path_buf());
         match self {
-            Self::Pi => pi_agent::resume_command(target_path),
-            Self::Omp => omp_agent::resume_command(target_path),
+            Self::Pi => pi_agent::resume_command(&runtime_target_path),
+            Self::Omp => omp_agent::resume_command(&runtime_target_path),
             Self::ClaudeCode => claude_code::resume_command(target_session_id),
             Self::Codex => codex::resume_command(target_session_id),
             Self::OpenCode => opencode::resume_command(),

--- a/src-tauri/src/domain/casr_min/providers/omp_agent.rs
+++ b/src-tauri/src/domain/casr_min/providers/omp_agent.rs
@@ -25,7 +25,7 @@ pub fn looks_like_session_content(content: &str) -> bool {
 }
 
 pub fn build_target_path(target_session_id: &str, now: chrono::DateTime<chrono::Utc>) -> Result<PathBuf, String> {
-    let root = crate::paths::omp_agent_sessions_dir().map(|dir| dir.join("bridge")).map_err(|_| "cannot determine OMP sessions directory".to_string())?;
+    let root = crate::paths::current_session_home_dir().map(|home| home.join(".omp").join("agent").join("sessions").join("bridge")).map_err(|_| "cannot determine OMP sessions directory".to_string())?;
     let stamp = now.format("%Y-%m-%dT%H-%M-%S%.3f").to_string();
     let suffix = target_session_id.chars().filter(|c| c.is_ascii_hexdigit()).take(8).collect::<String>();
     Ok(root.join(format!("{stamp}_{suffix}.jsonl")))

--- a/src-tauri/src/domain/casr_min/providers/opencode.rs
+++ b/src-tauri/src/domain/casr_min/providers/opencode.rs
@@ -35,6 +35,10 @@ pub fn session_roots() -> Vec<PathBuf> {
     dedup_existing_dirs(candidate_data_dirs())
 }
 
+pub fn session_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    dedup_existing_dirs(vec![home.join(DATA_DIRNAME), home.join(".local").join("share").join(XDG_DATA_DIRNAME)])
+}
+
 pub fn matches_path(path: &Path) -> bool {
     if path.file_name().and_then(|value| value.to_str()) == Some(DB_FILENAME) {
         return true;
@@ -162,7 +166,7 @@ fn candidate_data_dirs() -> Vec<PathBuf> {
 
     dirs.extend(cwd_ancestor_data_dirs());
 
-    for home in crate::paths::local_and_wsl_home_dirs() {
+    if let Ok(home) = crate::paths::home_dir() {
         dirs.push(home.join(DATA_DIRNAME));
         dirs.push(home.join(".local").join("share").join(XDG_DATA_DIRNAME));
     }
@@ -262,6 +266,11 @@ fn dedup_existing_dirs(paths: Vec<PathBuf>) -> Vec<PathBuf> {
 }
 
 fn choose_target_db_path(session: &CanonicalSession) -> Result<PathBuf, String> {
+    let config = crate::config::Config::load().unwrap_or_default();
+    if config.session_runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl {
+        return Ok(crate::paths::session_runtime_home_dir(&config)?.join(".local").join("share").join(XDG_DATA_DIRNAME).join(DB_FILENAME));
+    }
+
     if let Some(env_db) = env_db_path() {
         return Ok(env_db);
     }

--- a/src-tauri/src/domain/casr_min/providers/pi_agent.rs
+++ b/src-tauri/src/domain/casr_min/providers/pi_agent.rs
@@ -10,7 +10,7 @@ pub fn session_roots() -> Vec<PathBuf> {
 }
 
 pub fn build_target_path(target_session_id: &str, now: chrono::DateTime<chrono::Utc>) -> Result<PathBuf, String> {
-    let root = crate::paths::pi_agent_sessions_dir().map(|dir| dir.join("bridge")).map_err(|_| "cannot determine Pi sessions directory".to_string())?;
+    let root = crate::paths::current_session_home_dir().map(|home| home.join(".pi").join("agent").join("sessions").join("bridge")).map_err(|_| "cannot determine Pi sessions directory".to_string())?;
     let stamp = now.format("%Y-%m-%dT%H-%M-%S%.3f").to_string();
     let suffix = target_session_id.chars().filter(|c| c.is_ascii_hexdigit()).take(8).collect::<String>();
     Ok(root.join(format!("{stamp}_{suffix}.jsonl")))

--- a/src-tauri/src/domain/session_bridge/api.rs
+++ b/src-tauri/src/domain/session_bridge/api.rs
@@ -15,9 +15,12 @@ use tracing::{debug, warn};
 const PROVIDER_DETECTION_PROBE_BYTES: usize = 64 * 1024;
 
 pub fn default_session_dirs() -> Vec<PathBuf> {
+    let Ok(runtime_home) = crate::paths::current_session_home_dir() else {
+        return Vec::new();
+    };
     let mut dirs = Vec::new();
     for source in SessionBridgeSource::ALL {
-        for root in source.session_roots() {
+        for root in source.session_roots_for_home(&runtime_home) {
             if root.exists() && !dirs.iter().any(|existing| existing == &root) {
                 dirs.push(root);
             }

--- a/src-tauri/src/domain/session_bridge/types.rs
+++ b/src-tauri/src/domain/session_bridge/types.rs
@@ -53,25 +53,18 @@ impl SessionBridgeSource {
     }
 
     pub fn session_roots(self) -> Vec<PathBuf> {
-        match self {
-            Self::Pi => crate::paths::pi_agent_sessions_dir().ok().filter(|path| path.is_dir()).map(|path| vec![path]).unwrap_or_default(),
-            Self::Omp => crate::paths::omp_agent_sessions_dir().ok().filter(|path| path.is_dir()).map(|path| vec![path]).unwrap_or_default(),
-            Self::ClaudeCode => crate::domain::casr_min::providers::claude_code::session_roots(),
-            Self::Codex => crate::domain::casr_min::providers::codex::session_roots(),
-            Self::Gemini => crate::domain::casr_min::providers::gemini::session_roots(),
-            Self::Factory => crate::domain::casr_min::providers::factory::session_roots(),
-            Self::ClawdBot => crate::domain::casr_min::providers::clawdbot::session_roots(),
-            Self::OpenCode => crate::domain::casr_min::providers::opencode::session_roots(),
-            Self::Cursor => crate::domain::casr_min::providers::cursor::session_roots(),
-            Self::Antigravity => crate::domain::casr_min::providers::antigravity::session_roots(),
-        }
+        ProviderKind::from(self).session_roots()
+    }
+
+    pub fn session_roots_for_home(self, home: &Path) -> Vec<PathBuf> {
+        ProviderKind::from(self).session_roots_for_home(home)
     }
 
     pub fn matches_path(self, path: &Path) -> bool {
         let normalized = path.to_string_lossy().replace('\\', "/");
         match self {
-            Self::Pi => crate::paths::pi_agent_sessions_dir().ok().map(|path| path.to_string_lossy().replace('\\', "/")).is_some_and(|root| normalized.contains(&root)),
-            Self::Omp => crate::paths::omp_agent_sessions_dir().ok().map(|path| path.to_string_lossy().replace('\\', "/")).is_some_and(|root| normalized.contains(&root)),
+            Self::Pi => normalized.contains("/.pi/agent/sessions/"),
+            Self::Omp => normalized.contains("/.omp/agent/sessions/"),
             Self::ClaudeCode => normalized.contains("/.claude/projects/"),
             Self::Codex => normalized.contains("/.codex/sessions/"),
             Self::Gemini => crate::domain::casr_min::providers::gemini::is_session_file(path),
@@ -164,4 +157,25 @@ pub struct SessionBridgeConvertResult {
 
 pub(crate) fn map_read_result((provider, canonical): (ProviderKind, CanonicalSession)) -> (SessionBridgeSource, CanonicalSession) {
     (provider.into(), canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn omp_matches_wsl_unc_session_path() {
+        let path = Path::new(r"\\wsl.localhost\Ubuntu\home\demo\.omp\agent\sessions\project\session.jsonl");
+        assert!(SessionBridgeSource::Omp.matches_path(path));
+        assert!(!SessionBridgeSource::Pi.matches_path(path));
+    }
+
+    #[test]
+    fn omp_roots_are_resolved_from_supplied_runtime_home() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let sessions = temp.path().join(".omp").join("agent").join("sessions");
+        std::fs::create_dir_all(&sessions).expect("create OMP sessions");
+
+        assert_eq!(SessionBridgeSource::Omp.session_roots_for_home(temp.path()), vec![sessions]);
+    }
 }

--- a/src-tauri/src/domain/terminal/api.rs
+++ b/src-tauri/src/domain/terminal/api.rs
@@ -93,6 +93,14 @@ pub async fn open_session_in_terminal_impl(path: String, cwd: String, terminal: 
     log::info!("[Terminal] Pi: {pi_cmd}");
     log::info!("[Terminal] Resume command: {resume_cmd:?}");
 
+    #[cfg(target_os = "windows")]
+    {
+        let config = crate::config::Config::load().unwrap_or_default();
+        if config.session_runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl {
+            return open_session_in_wsl_terminal(&config, &path, &resolved_cwd, &pi_cmd, resume_cmd);
+        }
+    }
+
     let mut attempts: Vec<String> = Vec::new();
     let try_custom_first = requested_terminal != "auto" && !is_known_external_terminal(requested_terminal);
 
@@ -112,6 +120,45 @@ pub async fn open_session_in_terminal_impl(path: String, cwd: String, terminal: 
     }
 
     Err(format!("Failed to open external terminal. requested='{requested_terminal}', cwd='{}'. attempts: {}", resolved_cwd, attempts.join(" | ")))
+}
+
+#[cfg(target_os = "windows")]
+fn open_session_in_wsl_terminal(config: &crate::config::Config, path: &str, cwd: &str, pi_cmd: &str, resume_command: Option<&str>) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NEW_CONSOLE: u32 = 0x00000010;
+
+    let distro = config.wsl_distribution.as_deref().map(str::trim).filter(|value| !value.is_empty()).ok_or_else(|| "WSL runtime requires a selected distribution".to_string())?;
+
+    let linux_path = resolve_wsl_linux_path(distro, path).ok_or_else(|| format!("Cannot map session path into WSL distro {distro}: {path}"))?;
+    let linux_cwd = resolve_wsl_linux_path(distro, cwd).or_else(|| crate::paths::wsl_home_dir(distro).ok().and_then(|home| crate::paths::wsl_unc_path_to_linux(distro, &home))).unwrap_or_else(|| "/".to_string());
+    let command = build_resume_command(&linux_cwd, &linux_path, pi_cmd, resume_command);
+
+    log::info!("[Terminal][WSL] Distro: {distro}");
+    log::info!("[Terminal][WSL] CWD: {linux_cwd}");
+    log::info!("[Terminal][WSL] Path: {linux_path}");
+    log::info!("[Terminal][WSL] Command: {command}");
+
+    if command_exists("wt") {
+        Command::new("wt").arg("wsl.exe").arg("-d").arg(distro).arg("--cd").arg(&linux_cwd).arg("--").arg("sh").arg("-lc").arg(&command).spawn().map_err(|error| format!("Failed to launch WSL in Windows Terminal: {error}"))?;
+        return Ok(());
+    }
+
+    Command::new("wsl.exe").arg("-d").arg(distro).arg("--cd").arg(&linux_cwd).arg("--").arg("sh").arg("-lc").arg(&command).creation_flags(CREATE_NEW_CONSOLE).spawn().map_err(|error| format!("Failed to launch WSL terminal: {error}"))?;
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_wsl_linux_path(distro: &str, value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(path) = crate::paths::wsl_unc_path_to_linux(distro, Path::new(trimmed)) {
+        return Some(path);
+    }
+    let normalized = trimmed.replace('\\', "/");
+    normalized.starts_with('/').then_some(normalized)
 }
 
 pub async fn open_url_in_system_impl(url: String) -> Result<(), String> {

--- a/src-tauri/src/file_watcher.rs
+++ b/src-tauri/src/file_watcher.rs
@@ -10,7 +10,7 @@ use tauri::{AppHandle, Emitter, Manager};
 use tracing::{debug, error, info, warn};
 
 fn should_disable_watcher(config: &crate::config::Config) -> bool {
-    config.session_source_mode == crate::config::SessionSourceMode::Dataset
+    config.session_source_mode == crate::config::SessionSourceMode::Dataset || config.session_runtime_environment == crate::config::SessionRuntimeEnvironment::Wsl
 }
 
 /// File watcher state that can be managed by Tauri
@@ -125,7 +125,7 @@ pub fn start_watcher_for_all_dirs(app_handle: AppHandle) -> Result<FileWatcherSt
 
     let config = crate::config::load_config().unwrap_or_default();
     if should_disable_watcher(&config) {
-        debug!("File watcher disabled in dataset mode");
+        debug!("File watcher disabled for the current session source/runtime");
         return Ok(state);
     }
     let all_dirs = crate::core::scanner::get_all_session_dirs(&config);
@@ -139,7 +139,7 @@ pub fn start_watcher_for_all_dirs(app_handle: AppHandle) -> Result<FileWatcherSt
 pub fn restart_watcher_with_config(watcher_state: &FileWatcherState, app_handle: AppHandle) -> Result<(), String> {
     let config = crate::config::load_config().unwrap_or_default();
     if should_disable_watcher(&config) {
-        debug!("Skipping file watcher restart in dataset mode");
+        debug!("Skipping file watcher restart for the current session source/runtime");
         watcher_state.stop().ok();
         return Ok(());
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -522,6 +522,8 @@ fn main() {
             pi_session_manager::start_dataset_import,
             pi_session_manager::get_dataset_import_status,
             pi_session_manager::save_session_source,
+            pi_session_manager::list_wsl_distributions,
+            pi_session_manager::save_session_runtime_environment,
             pi_session_manager::save_session_scan_other_agents,
             pi_session_manager::save_external_session_providers,
             pi_session_manager::load_server_settings,

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -28,21 +28,21 @@ pub fn local_and_wsl_home_dirs() -> Vec<PathBuf> {
 }
 
 pub fn existing_home_relative_dirs(components: &[&str]) -> Vec<PathBuf> {
-    local_and_wsl_home_dirs()
-        .into_iter()
-        .map(|mut home| {
-            for component in components {
-                home.push(component);
-            }
-            home
-        })
-        .filter(|path| path.is_dir())
-        .fold(Vec::new(), |mut dirs, path| {
-            if !dirs.iter().any(|existing| existing == &path) {
-                dirs.push(path);
-            }
-            dirs
-        })
+    let Ok(mut path) = home_dir() else {
+        return Vec::new();
+    };
+    for component in components {
+        path.push(component);
+    }
+    path.is_dir().then_some(vec![path]).unwrap_or_default()
+}
+
+pub fn existing_relative_dir(home: &Path, components: &[&str]) -> Vec<PathBuf> {
+    let mut path = home.to_path_buf();
+    for component in components {
+        path.push(component);
+    }
+    path.is_dir().then_some(vec![path]).unwrap_or_default()
 }
 
 fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
@@ -64,21 +64,23 @@ fn wsl_home_dirs() -> Vec<PathBuf> {
     Vec::new()
 }
 
-#[cfg(target_os = "windows")]
-fn wsl_distribution_names() -> Vec<String> {
-    static WSL_DISTRIBUTIONS: OnceLock<Vec<String>> = OnceLock::new();
-    WSL_DISTRIBUTIONS
-        .get_or_init(|| {
-            let Ok(output) = std::process::Command::new("wsl.exe").args(["-l", "-q"]).output() else {
-                return Vec::new();
-            };
-            if !output.status.success() {
-                return Vec::new();
-            }
+pub fn wsl_distribution_names() -> Vec<String> {
+    #[cfg(target_os = "windows")]
+    {
+        let Ok(output) = std::process::Command::new("wsl.exe").args(["-l", "-q"]).output() else {
+            return Vec::new();
+        };
+        if !output.status.success() {
+            return Vec::new();
+        }
 
-            decode_wsl_output(&output.stdout).lines().map(|line| line.trim_matches('\u{feff}').trim().trim_matches('\0').to_string()).filter(|line| !line.is_empty()).collect()
-        })
-        .clone()
+        return decode_wsl_output(&output.stdout).lines().map(|line| line.trim_matches('\u{feff}').trim().trim_matches('\0').to_string()).filter(|line| !line.is_empty()).collect();
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Vec::new()
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -94,6 +96,70 @@ fn decode_wsl_output(bytes: &[u8]) -> String {
 #[cfg(target_os = "windows")]
 fn wsl_unc_home_dirs(distro: &str) -> Vec<PathBuf> {
     [format!("\\\\wsl.localhost\\{}\\home", distro), format!("\\\\wsl$\\{}\\home", distro)].into_iter().filter_map(|home_root| std::fs::read_dir(home_root).ok()).flat_map(|entries| entries.flatten().map(|entry| entry.path()).collect::<Vec<_>>()).filter(|path| path.is_dir()).collect()
+}
+
+pub fn wsl_linux_path_to_unc(distro: &str, linux_path: &str) -> PathBuf {
+    wsl_linux_path_to_unc_host("wsl.localhost", distro, linux_path)
+}
+
+fn wsl_linux_path_to_unc_host(host: &str, distro: &str, linux_path: &str) -> PathBuf {
+    let relative = linux_path.trim().trim_start_matches('/').replace('/', "\\");
+    if relative.is_empty() {
+        PathBuf::from(format!("\\\\{host}\\{distro}\\"))
+    } else {
+        PathBuf::from(format!("\\\\{host}\\{distro}\\{relative}"))
+    }
+}
+
+pub fn wsl_unc_path_to_linux(distro: &str, path: &Path) -> Option<String> {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    for host in ["//wsl.localhost/", "//wsl$/"] {
+        let prefix = format!("{host}{distro}/");
+        if normalized.len() >= prefix.len() && normalized[..prefix.len()].eq_ignore_ascii_case(&prefix) {
+            return Some(format!("/{}", &normalized[prefix.len()..]));
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn wsl_linux_home(distro: &str) -> Result<String, String> {
+    let output = std::process::Command::new("wsl.exe").args(["-d", distro, "--", "sh", "-lc", "printf %s \"$HOME\""]).output().map_err(|error| format!("Failed to query WSL home for {distro}: {error}"))?;
+    if !output.status.success() {
+        return Err(format!("Failed to query WSL home for {distro}: exit status {}", output.status));
+    }
+    let home = decode_wsl_output(&output.stdout).trim_matches('\0').trim().to_string();
+    if !home.starts_with('/') {
+        return Err(format!("WSL distro {distro} returned an invalid HOME: {home}"));
+    }
+    Ok(home)
+}
+
+#[cfg(target_os = "windows")]
+pub fn wsl_home_dir(distro: &str) -> Result<PathBuf, String> {
+    let linux_home = wsl_linux_home(distro)?;
+    let candidates = [wsl_linux_path_to_unc_host("wsl.localhost", distro, &linux_home), wsl_linux_path_to_unc_host("wsl$", distro, &linux_home)];
+    candidates.into_iter().find(|path| path.is_dir()).ok_or_else(|| format!("Cannot access WSL home for distro {distro}: {linux_home}"))
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn wsl_home_dir(_distro: &str) -> Result<PathBuf, String> {
+    Err("WSL runtime is only available on Windows".to_string())
+}
+
+pub fn session_runtime_home_dir(config: &crate::config::Config) -> Result<PathBuf, String> {
+    match config.session_runtime_environment {
+        crate::config::SessionRuntimeEnvironment::Local => home_dir(),
+        crate::config::SessionRuntimeEnvironment::Wsl => {
+            let distro = config.wsl_distribution.as_deref().map(str::trim).filter(|value| !value.is_empty()).ok_or_else(|| "WSL runtime requires a selected distribution".to_string())?;
+            wsl_home_dir(distro)
+        }
+    }
+}
+
+pub fn current_session_home_dir() -> Result<PathBuf, String> {
+    let config = crate::config::Config::load().unwrap_or_default();
+    session_runtime_home_dir(&config)
 }
 
 /// Global lock for tests that mutate HOME/PPM_TEST_DB environment variables.
@@ -199,6 +265,21 @@ mod tests {
         let _home = TestHomeGuard::set(temp.path());
         let dirs = existing_home_relative_dirs(&[".codex", "sessions"]);
 
-        assert!(dirs.iter().any(|dir| dir == &sessions_dir));
+        assert_eq!(dirs, vec![sessions_dir]);
+    }
+
+    #[test]
+    fn wsl_linux_path_maps_to_localhost_unc() {
+        let path = wsl_linux_path_to_unc("Ubuntu", "/home/demo/.omp/agent/sessions/a.jsonl");
+        assert_eq!(path.to_string_lossy(), r"\\wsl.localhost\Ubuntu\home\demo\.omp\agent\sessions\a.jsonl");
+    }
+
+    #[test]
+    fn wsl_unc_path_maps_back_to_linux_for_both_hosts() {
+        let localhost = Path::new(r"\\wsl.localhost\Ubuntu\home\demo\.pi\agent\sessions\a.jsonl");
+        let legacy = Path::new(r"\\wsl$\Ubuntu\home\demo\.pi\agent\sessions\a.jsonl");
+
+        assert_eq!(wsl_unc_path_to_linux("Ubuntu", localhost).as_deref(), Some("/home/demo/.pi/agent/sessions/a.jsonl"));
+        assert_eq!(wsl_unc_path_to_linux("Ubuntu", legacy).as_deref(), Some("/home/demo/.pi/agent/sessions/a.jsonl"));
     }
 }

--- a/src/components/settings/sections/DataSourcesSettings.tsx
+++ b/src/components/settings/sections/DataSourcesSettings.tsx
@@ -1,10 +1,13 @@
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FolderOpen, Plus, X } from "lucide-react";
+import { FolderOpen, Monitor, Plus, X } from "lucide-react";
 
 import SettingsCard from "@/components/settings/SettingsCard";
 import SettingsInput from "@/components/settings/SettingsInput";
+import SettingsSelect from "@/components/settings/SettingsSelect";
 import SettingsToggleRow from "@/components/settings/SettingsToggleRow";
-import type { AppSettings } from "@/components/settings/types";
+import { detectPlatform, type AppSettings } from "@/components/settings/types";
+import { invoke } from "@/transport";
 import ExternalSessionsSettings from "./ExternalSessionsSettings";
 import SessionSettings from "./SessionSettings";
 
@@ -26,6 +29,9 @@ export default function DataSourcesSettings({
   mode = "all",
 }: DataSourcesSettingsProps) {
   const { t } = useTranslation();
+  const isWindows = detectPlatform() === "windows";
+  const [wslDistributions, setWslDistributions] = useState<string[]>([]);
+  const [loadingWslDistributions, setLoadingWslDistributions] = useState(false);
   const includeDefaultDir = settings.advanced.includeDefaultPiSessionDir !== false;
   const extraDirs = (settings.advanced.sessionDirs || []).filter(
     (dir: string) => dir !== DEFAULT_SESSION_DIR,
@@ -35,6 +41,37 @@ export default function DataSourcesSettings({
 
   const buildSessionDirs = (includeDefault: boolean, nextDirs: string[]) =>
     includeDefault ? [DEFAULT_SESSION_DIR, ...nextDirs] : nextDirs;
+
+  useEffect(() => {
+    if (!isWindows) return;
+
+    let cancelled = false;
+    setLoadingWslDistributions(true);
+    void invoke<string[]>("list_wsl_distributions")
+      .then((distributions) => {
+        if (!cancelled) setWslDistributions(distributions);
+      })
+      .catch((error) => {
+        console.warn("Failed to list WSL distributions:", error);
+        if (!cancelled) setWslDistributions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingWslDistributions(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isWindows]);
+
+  const setRuntimeEnvironment = (environment: "local" | "wsl") => {
+    if (environment === "wsl" && !settings.session.wslDistro) {
+      const firstDistro = wslDistributions[0];
+      if (!firstDistro) return;
+      onUpdate("session", "wslDistro", firstDistro);
+    }
+    onUpdate("session", "runtimeEnvironment", environment);
+  };
 
   const setExtraDirs = (nextDirs: string[]) => {
     onUpdate("advanced", "sessionDirs", buildSessionDirs(includeDefaultDir, nextDirs));
@@ -57,6 +94,69 @@ export default function DataSourcesSettings({
 
   return (
     <div className="space-y-6">
+      {isWindows && (mode === "all" || mode === "local-paths") && (
+        <SettingsCard
+          title={t("settings.dataSources.runtimeTitle", "Session runtime")}
+          description={t(
+            "settings.dataSources.runtimeHelp",
+            "Choose whether local sessions are resolved from Windows or from a selected WSL distribution. Dataset mode is separate.",
+          )}
+          icon={<Monitor className="h-4 w-4" />}
+          searchKey="session-runtime-environment"
+          contentClassName="p-4"
+        >
+          <div className="space-y-3">
+            <SettingsSelect
+              value={settings.session.runtimeEnvironment}
+              onChange={(event) => setRuntimeEnvironment(event.target.value as "local" | "wsl")}
+            >
+              <option value="local">
+                {t("settings.dataSources.runtimeLocal", "Windows (Local)")}
+              </option>
+              <option value="wsl" disabled={wslDistributions.length === 0}>
+                {t("settings.dataSources.runtimeWsl", "WSL")}
+              </option>
+            </SettingsSelect>
+
+            {settings.session.runtimeEnvironment === "wsl" && (
+              <div className="space-y-1.5">
+                <div className="text-xs font-medium text-muted-foreground">
+                  {t("settings.dataSources.wslDistribution", "WSL distribution")}
+                </div>
+                <SettingsSelect
+                  value={settings.session.wslDistro}
+                  disabled={loadingWslDistributions || wslDistributions.length === 0}
+                  onChange={(event) => onUpdate("session", "wslDistro", event.target.value)}
+                >
+                  {wslDistributions.map((distribution) => (
+                    <option key={distribution} value={distribution}>
+                      {distribution}
+                    </option>
+                  ))}
+                </SettingsSelect>
+                <p className="text-xs text-muted-foreground">
+                  {loadingWslDistributions
+                    ? t("settings.dataSources.wslLoading", "Detecting WSL distributions...")
+                    : t(
+                        "settings.dataSources.wslHelp",
+                        "~ and default agent session paths resolve from this distribution's Linux $HOME. Terminal resume commands run inside the same distribution.",
+                      )}
+                </p>
+              </div>
+            )}
+
+            {!loadingWslDistributions && wslDistributions.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                {t(
+                  "settings.dataSources.wslUnavailable",
+                  "No WSL distributions were detected. Install or start a WSL distribution to enable WSL mode.",
+                )}
+              </p>
+            )}
+          </div>
+        </SettingsCard>
+      )}
+
       {(mode === "all" || mode === "local-paths") && (
         <SettingsCard
           title={t("settings.dataSources.localTitle", "Local session directories")}

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -117,6 +117,8 @@ export interface AppSettings {
     defaultViewMode: "list" | "directory" | "project";
     conversationModeEnabled: boolean;
     sourceMode: "local" | "dataset";
+    runtimeEnvironment: "local" | "wsl";
+    wslDistro: string;
     activeDatasetId: string;
     activeDatasetIds: string[];
     scanOtherAgentJsonl: boolean;
@@ -223,6 +225,8 @@ export const defaultSettings: AppSettings = {
     defaultViewMode: "project",
     conversationModeEnabled: true,
     sourceMode: "local",
+    runtimeEnvironment: "local",
+    wslDistro: "",
     activeDatasetId: "",
     activeDatasetIds: [],
     scanOtherAgentJsonl: false,

--- a/src/i18n/locales/en-US/settings.ts
+++ b/src/i18n/locales/en-US/settings.ts
@@ -324,6 +324,17 @@ export const settings = {
   },
   dataSources: {
     localTitle: "Local session directories",
+    runtimeTitle: "Session runtime",
+    runtimeHelp:
+      "Choose whether local sessions are resolved from Windows or from a selected WSL distribution. Dataset mode is separate.",
+    runtimeLocal: "Windows (Local)",
+    runtimeWsl: "WSL",
+    wslDistribution: "WSL distribution",
+    wslLoading: "Detecting WSL distributions...",
+    wslHelp:
+      "~ and default agent session paths resolve from this distribution's Linux $HOME. Terminal resume commands run inside the same distribution.",
+    wslUnavailable:
+      "No WSL distributions were detected. Install or start a WSL distribution to enable WSL mode.",
   },
   diagnostics: {
     maintenanceTitle: "Maintenance",

--- a/src/i18n/locales/zh-CN/settings.ts
+++ b/src/i18n/locales/zh-CN/settings.ts
@@ -319,6 +319,14 @@ export const settings = {
   },
   dataSources: {
     localTitle: "本地会话目录",
+    runtimeTitle: "会话运行环境",
+    runtimeHelp: "选择本地会话使用 Windows 还是指定的 WSL 发行版。数据集模式与运行环境相互独立。",
+    runtimeLocal: "Windows（本地）",
+    runtimeWsl: "WSL",
+    wslDistribution: "WSL 发行版",
+    wslLoading: "正在检测 WSL 发行版...",
+    wslHelp: "~ 和各 Agent 默认会话路径会解析到该发行版的 Linux $HOME；终端恢复命令也会在同一发行版内执行。",
+    wslUnavailable: "未检测到 WSL 发行版。安装或启动一个 WSL 发行版后即可启用 WSL 模式。",
   },
   diagnostics: {
     maintenanceTitle: "维护",

--- a/src/utils/sessionResume.test.ts
+++ b/src/utils/sessionResume.test.ts
@@ -4,12 +4,17 @@ import type { SessionInfo } from "@/types";
 
 const mocks = vi.hoisted(() => ({
   invoke: vi.fn(),
+  platform: "macos" as "macos" | "windows" | "linux",
   settings: {
     terminal: {
       defaultTerminal: "terminal",
       customTerminalCommand: "",
       piCommandPath: "/custom/pi",
       resumeCommand: "",
+    },
+    session: {
+      runtimeEnvironment: "local" as "local" | "wsl",
+      wslDistro: "",
     },
   },
 }));
@@ -24,12 +29,13 @@ vi.mock("@/utils/settingsApi", () => ({
 }));
 
 vi.mock("@/components/settings/types", () => ({
-  detectPlatform: () => "macos",
+  detectPlatform: () => mocks.platform,
   getPlatformDefaults: () => ({ defaultTerminal: "terminal" }),
 }));
 
 import {
   buildOmpResumeCommand,
+  buildPiResumeCommand,
   openSessionInTerminalDirect,
 } from "./sessionResume";
 
@@ -42,6 +48,9 @@ const ompSession = {
 describe("OMP session resume", () => {
   beforeEach(() => {
     mocks.invoke.mockReset();
+    mocks.platform = "macos";
+    mocks.settings.session.runtimeEnvironment = "local";
+    mocks.settings.session.wslDistro = "";
   });
 
   it("always uses the omp binary instead of the configured Pi binary", () => {
@@ -65,5 +74,35 @@ describe("OMP session resume", () => {
       resumeCommand:
         'cd "/Users/demo/project" && omp --session "/Users/demo/.omp/agent/sessions/project/session.jsonl"',
     });
+  });
+
+  it("converts WSL UNC paths to Linux paths and uses Linux shell syntax", () => {
+    mocks.platform = "windows";
+    mocks.settings.session.runtimeEnvironment = "wsl";
+    mocks.settings.session.wslDistro = "Ubuntu";
+    const session = {
+      ...ompSession,
+      path: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\.omp\\agent\\sessions\\project\\session.jsonl",
+      cwd: "/home/demo/project",
+    } as SessionInfo;
+
+    expect(buildOmpResumeCommand(session)).toBe(
+      'cd "/home/demo/project" && omp --session "/home/demo/.omp/agent/sessions/project/session.jsonl"',
+    );
+  });
+
+  it("uses the Linux pi command in WSL instead of a Windows-configured Pi path", () => {
+    mocks.platform = "windows";
+    mocks.settings.session.runtimeEnvironment = "wsl";
+    mocks.settings.session.wslDistro = "Ubuntu";
+    const session = {
+      ...ompSession,
+      path: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\.pi\\agent\\sessions\\project\\session.jsonl",
+      cwd: "/home/demo/project",
+    } as SessionInfo;
+
+    expect(buildPiResumeCommand(session)).toBe(
+      'cd "/home/demo/project" && pi --session "/home/demo/.pi/agent/sessions/project/session.jsonl"',
+    );
   });
 });

--- a/src/utils/sessionResume.ts
+++ b/src/utils/sessionResume.ts
@@ -27,9 +27,42 @@ export interface OpenSessionInTerminalOverrides extends ResumeCommandOverrides {
  * Windows we emit cmd-compatible `cd /d "X" & pi ...` (`&` runs unconditionally
  * and is understood by both cmd and modern PowerShell).
  */
+function toWslLinuxPath(value: string, distro: string): string {
+  if (!value) return value;
+  const normalized = value.replace(/\\/g, "/");
+  const lower = normalized.toLowerCase();
+  for (const host of ["//wsl.localhost/", "//wsl$/"]) {
+    const prefix = `${host}${distro}/`;
+    if (lower.startsWith(prefix.toLowerCase())) {
+      return `/${normalized.slice(prefix.length)}`;
+    }
+  }
+  return normalized.startsWith("/") ? normalized : value;
+}
+
+function isWslRuntime(): boolean {
+  const settings = getCachedSettings();
+  return (
+    detectPlatform() === "windows" &&
+    settings.session?.runtimeEnvironment === "wsl"
+  );
+}
+
+function runtimePath(value: string): string {
+  const settings = getCachedSettings();
+  if (isWslRuntime() && settings.session?.wslDistro) {
+    return toWslLinuxPath(value, settings.session.wslDistro);
+  }
+  return value;
+}
+
 export function buildChangeDirAndRun(cwd: string, cmd: string): string {
   if (!cwd) return cmd;
+  const settings = getCachedSettings();
   if (detectPlatform() === "windows") {
+    if (settings.session?.runtimeEnvironment === "wsl") {
+      return `cd "${runtimePath(cwd)}" && ${cmd}`;
+    }
     // cmd.exe syntax; PowerShell also accepts `cd` (alias for Set-Location) and
     // `&` as a statement separator. `/d` lets cmd switch drives.
     return `cd /d "${cwd}" & ${cmd}`;
@@ -43,8 +76,8 @@ function applyResumeTemplate(
   piCommand: string,
 ): string {
   return template
-    .replace(/\{cwd\}/g, session.cwd || "")
-    .replace(/\{path\}/g, session.path)
+    .replace(/\{cwd\}/g, runtimePath(session.cwd || ""))
+    .replace(/\{path\}/g, runtimePath(session.path))
     .replace(/\{pi\}/g, piCommand);
 }
 
@@ -62,8 +95,8 @@ export function buildOmpResumeCommand(
   const ompCommand = "omp";
 
   if (!template.trim()) {
-    const baseCommand = `${ompCommand} --session "${session.path}"`;
-    return buildChangeDirAndRun(session.cwd || "", baseCommand);
+    const baseCommand = `${ompCommand} --session "${runtimePath(session.path)}"`;
+    return buildChangeDirAndRun(runtimePath(session.cwd || ""), baseCommand);
   }
 
   return applyResumeTemplate(template, session, ompCommand);
@@ -76,11 +109,13 @@ export function buildPiResumeCommand(
   const settings = getCachedSettings();
   const template =
     overrides.resumeCommand ?? settings.terminal?.resumeCommand ?? "";
-  const piCommand = overrides.piPath ?? settings.terminal?.piCommandPath ?? "pi";
+  const piCommand =
+    overrides.piPath ??
+    (isWslRuntime() ? "pi" : settings.terminal?.piCommandPath ?? "pi");
 
   if (!template.trim()) {
-    const baseCommand = `${piCommand} --session \"${session.path}\"`;
-    return buildChangeDirAndRun(session.cwd || "", baseCommand);
+    const baseCommand = `${piCommand} --session \"${runtimePath(session.path)}\"`;
+    return buildChangeDirAndRun(runtimePath(session.cwd || ""), baseCommand);
   }
 
   const hasPlaceholders =
@@ -92,8 +127,8 @@ export function buildPiResumeCommand(
     const sessionSuffix = session.id ? session.id.slice(0, 4) : "pi";
     const sessionName = `pi-${sessionSuffix}`;
     const nestedCommand = session.cwd
-      ? buildChangeDirAndRun(session.cwd, `${piCommand} --session \"${session.path}\"`)
-      : `${piCommand} --session \"${session.path}\"`;
+      ? buildChangeDirAndRun(runtimePath(session.cwd), `${piCommand} --session \"${runtimePath(session.path)}\"`)
+      : `${piCommand} --session \"${runtimePath(session.path)}\"`;
     return `${template.replace(/-s\\s+pi\\b/, `-s ${sessionName}`)} '${nestedCommand}'`;
   }
 
@@ -106,11 +141,13 @@ export function buildPiForkCommand(
   const settings = getCachedSettings();
   const template =
     overrides.resumeCommand ?? settings.terminal?.resumeCommand ?? "";
-  const piCommand = overrides.piPath ?? settings.terminal?.piCommandPath ?? "pi";
+  const piCommand =
+    overrides.piPath ??
+    (isWslRuntime() ? "pi" : settings.terminal?.piCommandPath ?? "pi");
 
   if (!template.trim()) {
-    const baseCommand = `${piCommand} --fork "${session.path}"`;
-    return buildChangeDirAndRun(session.cwd || "", baseCommand);
+    const baseCommand = `${piCommand} --fork "${runtimePath(session.path)}"`;
+    return buildChangeDirAndRun(runtimePath(session.cwd || ""), baseCommand);
   }
 
   const hasPlaceholders =
@@ -122,8 +159,8 @@ export function buildPiForkCommand(
     const sessionSuffix = session.id ? session.id.slice(0, 4) : "pi";
     const sessionName = `pi-${sessionSuffix}`;
     const nestedCommand = session.cwd
-      ? buildChangeDirAndRun(session.cwd, `${piCommand} --fork "${session.path}"`)
-      : `${piCommand} --fork "${session.path}"`;
+      ? buildChangeDirAndRun(runtimePath(session.cwd), `${piCommand} --fork "${runtimePath(session.path)}"`)
+      : `${piCommand} --fork "${runtimePath(session.path)}"`;
     return `${template.replace(/-s\\s+pi\b/, `-s ${sessionName}`)} '${nestedCommand}'`;
   }
 
@@ -206,7 +243,9 @@ export async function openSessionInTerminalDirect(
   const customCommand =
     settings.terminal?.customTerminalCommand || overrides.customCommand || "";
   const sourceSlug = getSessionSourceSlug(session.path);
-  const piPath = overrides.piPath ?? settings.terminal?.piCommandPath ?? "pi";
+  const piPath =
+    overrides.piPath ??
+    (isWslRuntime() ? "pi" : settings.terminal?.piCommandPath ?? "pi");
   const resumeCommand =
     overrides.resumeCommand ?? settings.terminal?.resumeCommand ?? "";
   const isOmpSession = sourceSlug === "omp";

--- a/src/utils/settingsApi.test.ts
+++ b/src/utils/settingsApi.test.ts
@@ -141,6 +141,55 @@ describe('saveAppSettings', () => {
     })
   })
 
+  it('syncs WSL runtime environment changes independently from dataset source mode', async () => {
+    const { saveAppSettings, getCachedSettings, loadAppSettings } = await import('./settingsApi')
+    const defaults = getCachedSettings()
+    const base: AppSettings = {
+      ...defaults,
+      advanced: { ...defaults.advanced, sessionDirs: ['~/.pi/agent/sessions'] },
+      session: {
+        ...defaults.session,
+        sourceMode: 'local',
+        runtimeEnvironment: 'local',
+        wslDistro: '',
+        activeDatasetId: '',
+        activeDatasetIds: [],
+        scanOtherAgentJsonl: false,
+        externalSessionProviders: [],
+      },
+    }
+
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'load_app_settings') {
+        return base
+      }
+      return undefined
+    })
+
+    await loadAppSettings()
+    invokeMock.mockClear()
+    saveSessionSourceMock.mockClear()
+
+    await saveAppSettings({
+      ...base,
+      session: {
+        ...base.session,
+        runtimeEnvironment: 'wsl',
+        wslDistro: 'Ubuntu',
+      },
+    })
+
+    expect(invokeMock.mock.calls.map((call) => call[0])).toEqual([
+      'save_app_settings',
+      'save_session_runtime_environment',
+    ])
+    expect(invokeMock).toHaveBeenCalledWith('save_session_runtime_environment', {
+      environment: 'wsl',
+      wslDistribution: 'Ubuntu',
+    })
+    expect(saveSessionSourceMock).not.toHaveBeenCalled()
+  })
+
   it('syncs only changed heavy settings fields', async () => {
     const { saveAppSettings, getCachedSettings, loadAppSettings } = await import('./settingsApi')
     const defaults = getCachedSettings()

--- a/src/utils/settingsApi.ts
+++ b/src/utils/settingsApi.ts
@@ -17,6 +17,8 @@ interface BackendSyncState {
   extraPaths: string[];
   includeDefaultPiSessionDir: boolean;
   sourceMode: "local" | "dataset";
+  runtimeEnvironment: "local" | "wsl";
+  wslDistro: string;
   activeDatasetId: string;
   activeDatasetIds: string[];
   scanOtherAgentJsonl: boolean;
@@ -34,6 +36,8 @@ function buildBackendSyncState(settings: AppSettings): BackendSyncState {
     ),
     includeDefaultPiSessionDir: settings.advanced.includeDefaultPiSessionDir !== false,
     sourceMode: settings.session.sourceMode,
+    runtimeEnvironment: settings.session.runtimeEnvironment,
+    wslDistro: settings.session.wslDistro || "",
     activeDatasetId: settings.session.activeDatasetId || "",
     activeDatasetIds: settings.session.activeDatasetIds || [],
     scanOtherAgentJsonl: settings.session.scanOtherAgentJsonl !== false,
@@ -159,6 +163,10 @@ function mergeDefaults(raw: Partial<AppSettings>): AppSettings {
     sourceMode: (rawSession?.sourceMode === "dataset" ? "dataset" : "local") as
       | "local"
       | "dataset",
+    runtimeEnvironment: (rawSession?.runtimeEnvironment === "wsl" ? "wsl" : "local") as
+      | "local"
+      | "wsl",
+    wslDistro: typeof rawSession?.wslDistro === "string" ? rawSession.wslDistro : "",
     activeDatasetId: activeDatasetIds[0] || "",
     activeDatasetIds,
     externalSessionProviders,
@@ -336,6 +344,22 @@ export async function saveAppSettings(settings: AppSettings): Promise<void> {
       });
     } catch (e) {
       console.warn("Failed to sync default Pi session directory setting:", e);
+      syncSucceeded = false;
+    }
+  }
+
+  if (
+    !previousBackendSyncState ||
+    previousBackendSyncState.runtimeEnvironment !== nextBackendSyncState.runtimeEnvironment ||
+    previousBackendSyncState.wslDistro !== nextBackendSyncState.wslDistro
+  ) {
+    try {
+      await invoke("save_session_runtime_environment", {
+        environment: nextBackendSyncState.runtimeEnvironment,
+        wslDistribution: nextBackendSyncState.wslDistro || null,
+      });
+    } catch (e) {
+      console.warn("Failed to sync session runtime environment:", e);
       syncSucceeded = false;
     }
   }


### PR DESCRIPTION
## Summary

- add an explicit Windows Local / WSL session runtime, kept separate from the Local sessions / Dataset source mode
- resolve `~` and provider default roots from the selected WSL distro default user `$HOME`
- stop Local mode from implicitly mixing WSL session roots; Pi, OMP, Codex, Claude Code, OpenCode, Gemini, Factory, ClawdBot, Cursor, and Antigravity share the runtime-home model
- map Linux paths to WSL UNC paths for Windows-side reading and map UNC paths back to Linux for resume/conversion commands
- run Open/Resume inside the selected distro via `wsl.exe`; WSL mode uses Linux shell/path semantics
- keep conversion targets in the active runtime and disable the native file watcher in WSL mode for the first implementation
- add Windows-only runtime settings UI and backend persistence / cache refresh commands

## Validation

- `cargo test -p pi-session-manager --lib` — 191 passed
- frontend Vitest — 145 files / 772 tests passed
- targeted WSL/settings tests — 10 passed
- TypeScript typecheck — passed
- production Vite build — passed
- `git diff --check` and `cargo fmt --check` — passed
- repository CI includes `windows-latest` / `x86_64-pc-windows-msvc` desktop check and tests to compile the Windows-only `wsl.exe` launch branch

Closes #54