### PR TITLE
fix(updater): preserve portable Linux installs on update

### DIFF
--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -10,6 +10,11 @@ use tauri::{AppHandle, Emitter, Runtime};
 #[cfg(feature = "gui")]
 use tauri_plugin_updater::UpdaterExt;
 
+#[cfg(all(feature = "gui", target_os = "linux"))]
+use std::io::Read;
+#[cfg(all(feature = "gui", target_os = "linux"))]
+use std::process::Stdio;
+
 #[cfg(feature = "gui")]
 const UPDATE_CHANNELS_JSON: &str = include_str!("../../../src/runtime-data/update-channels.json");
 #[cfg(feature = "gui")]
@@ -114,6 +119,110 @@ pub async fn check_app_update(app: AppHandle, channel: Option<String>) -> Result
     Ok(update.map(|item| AppUpdateMetadata { current_version: item.current_version.clone(), version: item.version.clone(), date: item.date.map(|value| value.to_string()), body: item.body.clone(), raw_json: item.raw_json.clone() }))
 }
 
+/// True when the file carries the AppImage type-2 magic: an ELF header
+/// followed by the "AI" bytes at offset 8.
+#[cfg(feature = "gui")]
+fn is_appimage_bytes(bytes: &[u8]) -> bool {
+    bytes.len() > 9 && &bytes[..4] == b"\x7fELF" && &bytes[8..10] == b"AI"
+}
+
+/// Detects whether the running app is an AppImage install.
+///
+/// The AppImage runtime sets `APPIMAGE` to the AppImage file path. Portable
+/// (linuxdeploy-extracted) installs run a plain ELF, which is only an AppImage
+/// container when it carries the "AI" magic.
+#[cfg(all(feature = "gui", target_os = "linux"))]
+fn is_appimage_install() -> bool {
+    if let Ok(appimage) = std::env::var("APPIMAGE") {
+        return !appimage.is_empty();
+    }
+    let Ok(mut exe) = std::fs::File::open(std::env::current_exe().unwrap_or_default()) else {
+        return false;
+    };
+    let mut header = [0u8; 10];
+    exe.read_exact(&mut header).is_ok() && is_appimage_bytes(&header)
+}
+
+/// Detects a linuxdeploy-extracted ("portable") install layout, where the
+/// binary lives at `{root}/usr/bin/{name}` and bundled libraries live in
+/// `{root}/usr/lib`. Returns the app root when the layout matches.
+#[cfg(all(feature = "gui", target_os = "linux"))]
+fn linux_install_root() -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let bin_dir = exe.parent()?;
+    if bin_dir.file_name()?.to_str()? != "bin" {
+        return None;
+    }
+    let usr_dir = bin_dir.parent()?;
+    if usr_dir.file_name()?.to_str()? != "usr" {
+        return None;
+    }
+    if !usr_dir.join("lib").is_dir() {
+        return None;
+    }
+    Some(usr_dir.parent()?.to_path_buf())
+}
+
+/// Installs a downloaded AppImage over a portable (linuxdeploy-extracted)
+/// install in place: extract the AppImage and copy the fresh tree over the
+/// install root, preserving the extracted layout so launch scripts that prefer
+/// system libraries (e.g. a wrapper that sets `LD_LIBRARY_PATH=/usr/lib` first)
+/// keep working. Overwriting the binary with the AppImage file itself would
+/// make every launch run with the AppImage's bundled WebKitGTK, which can fail
+/// on systems with a newer system WebKit.
+#[cfg(all(feature = "gui", target_os = "linux"))]
+fn install_extracted_appimage(bytes: Vec<u8>, install_root: &std::path::Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let exe_name = std::env::current_exe().ok().and_then(|path| path.file_name().map(|name| name.to_string_lossy().into_owned())).unwrap_or_else(|| "pi-session-manager".to_string());
+    let pid = std::process::id();
+    let appimage_path = std::env::temp_dir().join(format!("psm-update-{pid}.AppImage"));
+    let work_dir = std::env::temp_dir().join(format!("psm-update-extract-{pid}"));
+
+    let finish = |result: Result<(), String>| {
+        let _ = std::fs::remove_file(&appimage_path);
+        let _ = std::fs::remove_dir_all(&work_dir);
+        result
+    };
+
+    // Stage the downloaded AppImage and make it executable.
+    std::fs::write(&appimage_path, &bytes).map_err(|error| format!("Failed to stage update bundle: {error}"))?;
+    {
+        let mut perms = std::fs::metadata(&appimage_path).map_err(|error| format!("Failed to stat staged update bundle: {error}"))?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&appimage_path, perms).map_err(|error| format!("Failed to make update bundle executable: {error}"))?;
+    }
+    std::fs::create_dir_all(&work_dir).map_err(|error| format!("Failed to create extraction directory: {error}"))?;
+
+    // Extract the AppImage (its runtime honors --appimage-extract without FUSE).
+    let status = Command::new(&appimage_path).arg("--appimage-extract").current_dir(&work_dir).stdout(Stdio::null()).stderr(Stdio::null()).status().map_err(|error| format!("Failed to run AppImage extractor: {error}"))?;
+    if !status.success() {
+        return finish(Err("Failed to extract update bundle".to_string()));
+    }
+    let extracted = work_dir.join("squashfs-root");
+    if !extracted.is_dir() {
+        return finish(Err("Update bundle did not contain a valid AppImage payload".to_string()));
+    }
+
+    // Copy the fresh tree over the install root (preserves permissions and symlinks).
+    let status = Command::new("cp").arg("-a").arg(extracted.join(".")).arg(install_root).status().map_err(|error| format!("Failed to install update: {error}"))?;
+    if !status.success() {
+        return finish(Err("Failed to copy update into install directory".to_string()));
+    }
+
+    // Make sure the new binary is executable.
+    let new_exe = install_root.join("usr").join("bin").join(&exe_name);
+    {
+        let mut perms = std::fs::metadata(&new_exe).map_err(|error| format!("Failed to stat installed binary: {error}"))?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&new_exe, perms).map_err(|error| format!("Failed to make installed binary executable: {error}"))?;
+    }
+
+    log::info!("Installed update over portable install at {}", install_root.display());
+    finish(Ok(()))
+}
+
 #[cfg(feature = "gui")]
 #[tauri::command]
 pub async fn download_and_install_app_update(app: AppHandle, channel: Option<String>, request_id: String) -> Result<(), String> {
@@ -122,21 +231,32 @@ pub async fn download_and_install_app_update(app: AppHandle, channel: Option<Str
 
     let event_name = format!("app-updater-progress:{request_id}");
     let mut started = false;
-    update
-        .download_and_install(
-            |chunk_length, content_length| {
-                if !started {
-                    started = true;
-                    let _ = app.emit(&event_name, AppUpdateDownloadEvent::Started { content_length });
-                }
-                let _ = app.emit(&event_name, AppUpdateDownloadEvent::Progress { chunk_length });
-            },
-            || {
-                let _ = app.emit(&event_name, AppUpdateDownloadEvent::Finished);
-            },
-        )
-        .await
-        .map_err(|error| format!("Failed to download and install update: {error}"))
+    let progress = |chunk_length: usize, content_length: Option<u64>| {
+        if !started {
+            started = true;
+            let _ = app.emit(&event_name, AppUpdateDownloadEvent::Started { content_length });
+        }
+        let _ = app.emit(&event_name, AppUpdateDownloadEvent::Progress { chunk_length });
+    };
+    let finished = || {
+        let _ = app.emit(&event_name, AppUpdateDownloadEvent::Finished);
+    };
+
+    // Linux portable installs must not be overwritten with the AppImage file:
+    // the AppImage bundles its own WebKitGTK, which can break the webview on
+    // systems with a newer system WebKit (see install_extracted_appimage).
+    // Keep the extracted layout instead. Other layouts (and all non-Linux
+    // platforms) keep the plugin's default installer.
+    #[cfg(target_os = "linux")]
+    if !is_appimage_install() {
+        if let Some(install_root) = linux_install_root() {
+            let bytes = update.download(progress, finished).await.map_err(|error| format!("Failed to download update: {error}"))?;
+            return install_extracted_appimage(bytes, &install_root);
+        }
+        log::info!("Skipping portable-install updater path: no linuxdeploy layout detected");
+    }
+
+    update.download_and_install(progress, finished).await.map_err(|error| format!("Failed to download and install update: {error}"))
 }
 
 #[cfg(feature = "gui")]
@@ -166,5 +286,25 @@ mod tests {
         assert!(beta[0].as_str().contains("/beta/latest.json"));
         assert!(stable[1].as_str().contains("@update-manifests/stable/latest.json"));
         assert!(beta[1].as_str().contains("@update-manifests/beta/latest.json"));
+    }
+
+    #[test]
+    fn detects_appimage_type2_magic() {
+        let mut appimage = [0u8; 10];
+        appimage[..4].copy_from_slice(b"\x7fELF");
+        appimage[8..10].copy_from_slice(b"AI");
+        assert!(is_appimage_bytes(&appimage));
+
+        // A plain ELF binary has no "AI" magic.
+        let mut plain_elf = [0u8; 10];
+        plain_elf[..4].copy_from_slice(b"\x7fELF");
+        assert!(!is_appimage_bytes(&plain_elf));
+
+        // Short inputs and non-ELF magic are rejected.
+        assert!(!is_appimage_bytes(&[]));
+        assert!(!is_appimage_bytes(&appimage[..9]));
+        let mut not_elf = [0u8; 10];
+        not_elf[8..10].copy_from_slice(b"AI");
+        assert!(!is_appimage_bytes(&not_elf));
     }
 }


### PR DESCRIPTION
The tauri-plugin-updater default installer overwrites the running executable with the downloaded AppImage. For portable (linuxdeploy-extracted) installs this turns the launch target into an AppImage that bundles its own WebKitGTK, which can fail against a newer system WebKit (e.g. EGL_BAD_PARAMETER abort on modern Mesa), leaving the desktop window blank while the web UI keeps working.

Detect the install type on Linux: real AppImage installs keep the plugin's default in-place replacement, while portable installs download the AppImage, extract it with --appimage-extract, and copy the fresh tree over the install root, preserving the extracted layout so launch scripts that prefer system libraries continue to work.