### PR TITLE
style(messages): give user message bubbles a distinct background

### DIFF
--- a/src/styles/_messages.less
+++ b/src/styles/_messages.less
@@ -9,13 +9,13 @@
   opacity: 0.7;
 }
 
-// User Message — same surface color as the page, delineated by a neutral hairline border
+// User Message — distinct bubble color (messenger-style), user messages stand out from assistant
 .user-message {
   position: relative;
   min-width: 0;
   padding: 10px 14px 12px;
   color: var(--userMessageText);
-  background: transparent;
+  background: var(--userMessageBg);
   border: 1px solid rgb(var(--color-border) / 0.55);
   border-radius: 10px;
 }


### PR DESCRIPTION
## Summary

Give user message bubbles a distinct background color (`var(--userMessageBg)`) instead of rendering them as transparent with only a hairline border. User messages now read as a solid "messenger-style" bubble and clearly stand out from assistant messages.

## Change

`src/styles/_messages.less` (`.user-message`):
- `background: transparent` → `background: var(--userMessageBg)`
- updated the comment to match the new intent

The `--userMessageBg` custom property is already defined in the built-in themes (`src/styles/_variables.less`, `src/styles/_themes.less`) and is resolved per-theme via `piTheme.ts`, so no new theming surface is introduced.

## Motivation

Previously user messages relied on a subtle 1px hairline border to delineate them from the page surface, which can be hard to distinguish at a glance, especially in light themes. Using the already-present `--userMessageBg` makes user bubbles visually distinct without changing layout or adding new theme variables.

<img width="1257" height="767" alt="Screenshot_20260831_100223" src="https://github.com/user-attachments/assets/b766857a-3f31-4174-9bd5-f847450f72c5" />
<img width="1257" height="766" alt="Screenshot_20260831_100118" src="https://github.com/user-attachments/assets/986ff3f7-a3e3-481f-bead-6dad60822f5d" />


## Testing

- [x] Visual check in light theme
- [x] Visual check in dark theme
